### PR TITLE
Add troff dev environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,12 @@ Building
 If you're actually able to compile and run a codebase this ancient, for
 God's sake, [please send a pull-request][2].
 
+Setup environment
+-----------------
+Run `./setup.sh` while the environment still has network access to
+install modern troff tools along with BCPL and ACK compilers and their
+dependencies. The script also installs Python and Node utilities useful
+for disassembling and fuzzing troff-based software.
+
 [1]: https://web.archive.org/web/20060823034049/http://www.tuhs.org/Archive/PDP-11/Distributions/usdl/bostic_pwb.tar.gz
 [2]: https://github.com/Alhadis/otroff/pulls

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# setup.sh - Install troff tooling, BCPL, and ACK compilers
+# This script should be run while network access is available.
+set -e
+
+# Update package lists
+apt-get update
+
+# Install apt packages for troff and development
+apt-get install -y --no-install-recommends \
+    build-essential git clang gdb valgrind afl++ \
+    strace ltrace binutils autoconf automake libtool \
+    pkg-config groff groff-base mandoc \
+    radare2 \
+    bcpl bcpl-dev ack ack-dev
+
+# Upgrade pip and install Python tooling for analysis
+python3 -m pip install --upgrade pip
+python3 -m pip install capstone lief unicorn pwntools pyelftools r2pipe hexdump rich troff-utils
+
+# Install any troff tooling available via npm
+if command -v npm >/dev/null 2>&1; then
+    npm install -g troff
+fi
+
+


### PR DESCRIPTION
## Summary
- add `setup.sh` script for installing modern troff tooling and related packages
- document setup instructions in README

## Testing
- `git status --short`