### PR TITLE
Add 64-bit Makefile and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+CC ?= cc
+CPU ?= native
+
+# Map CPU values to 64-bit -march options
+ifeq ($(CPU),x86-64)
+    MARCH := x86-64
+else ifeq ($(CPU),haswell)
+    MARCH := haswell
+else
+    MARCH := $(CPU)
+endif
+
+CFLAGS ?= -std=gnu89 -Wall -O2 -march=$(MARCH)
+LDFLAGS ?=
+
+# Collect source files across the project
+SRC_C := $(wildcard croff/*.c neqn/*.c tbl/*.c)
+OBJDIR := build
+OBJ := $(patsubst %.c,$(OBJDIR)/%.o,$(SRC_C))
+
+all: $(OBJ)
+
+$(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(OBJDIR)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -14,8 +14,18 @@ are back to October 25th, 1978.
 
 Building
 --------
-If you're actually able to compile and run a codebase this ancient, for
-God's sake, [please send a pull-request][2].
+Run `./setup.sh` while network access is available to install the
+required toolchain.  Afterwards the code can be built using `make`.
+Object files are compiled with the `-std=gnu89` option so that the
+legacy sources build cleanly on modern compilers.  The target CPU can be
+specified via the `CPU` variable, for example:
+
+```
+make              # build using the host CPU
+make CPU=x86-64   # build using generic x86‑64 settings
+make CPU=haswell  # build for newer Intel chips
+```
+
 
 Setup environment
 -----------------


### PR DESCRIPTION
## Summary
- add a top-level Makefile to build object files with GNU89 and 64-bit `-march`
- document the new `make` based build procedure

## Testing
- `make -n | head -n 20`
