### PR TITLE
Modernize C declarations

### DIFF
--- a/croff/n1.c
+++ b/croff/n1.c
@@ -122,13 +122,11 @@ int ms[] {31,28,31,30,31,30,31,31,30,31,30,31};
 #ifndef NROFF
 int acctf;
 #endif
-static char Sccsid[] "@(#)n1.c	1.7 of 4/26/77";
+static char Sccsid[] = "@(#)n1.c  1.7 of 4/26/77";
 
-main(argc,argv)
-int argc;
-char **argv;
+int main(int argc, char *argv[])
 {
-	char *p, *q;
+    char *p, *q;
 	int *cframe;
 	register i, j;
 	extern catch(), fpecatch(), kcatch();

--- a/croff/n10.c
+++ b/croff/n10.c
@@ -33,7 +33,7 @@ extern int xxx;
 int dtab;
 int bdmode;
 int plotmode;
-static char Sccsid[] "@(#)n10.c	1.3 of 4/26/77";
+static char Sccsid[] = "@(#)n10.c  1.3 of 4/26/77";
 
 ptinit(){
 	register i;

--- a/croff/n2.c
+++ b/croff/n2.c
@@ -57,7 +57,7 @@ int error;
 #ifndef NROFF
 extern int acctf;
 #endif
-static char Sccsid[] "@(#)n2.c	1.8 of 5/13/77";
+static char Sccsid[] = "@(#)n2.c  1.8 of 5/13/77";
 
 pchar(c)
 int c;

--- a/croff/n3.c
+++ b/croff/n3.c
@@ -60,7 +60,7 @@ extern struct contab {
 int blist[NBLIST];
 int wbuf[BLK];
 int rbuf[BLK];
-static char Sccsid[] "@(#)n3.c	1.3 of 3/29/77";
+static char Sccsid[] = "@(#)n3.c  1.3 of 3/29/77";
 
 caseig(){
 	register i;

--- a/croff/n4.c
+++ b/croff/n4.c
@@ -51,7 +51,7 @@ extern struct contab {
 	int rq;
 	int (*f)();
 }contab[NM];
-static char Sccsid[] "@(#)n4.c	1.4 of 4/26/77";
+static char Sccsid[] = "@(#)n4.c  1.4 of 4/26/77";
 
 setn()
 {

--- a/croff/n7.c
+++ b/croff/n7.c
@@ -105,7 +105,26 @@ extern int nrbits;
 extern int nmbits;
 extern int xxx;
 int brflg;
-static char Sccsid[] "@(#)n7.c	1.2 of 3/4/77";
+static char Sccsid[] = "@(#)n7.c  1.2 of 3/4/77";
+int tbreak(void);
+int donum(void);
+int text(void);
+int nofill(void);
+int callsp(void);
+int ckul(void);
+int storeline(int c, int w);
+int newline(int a);
+int findn1(int a);
+int chkpn(void);
+int findt(int a);
+int findt1(void);
+int eject(int *a);
+int movword(void);
+int horiz(int i);
+int setnel(void);
+int getword(int x);
+int storeword(int c, int w);
+int gettch(void);
 
 tbreak(){
 	register *i, j, pad;

--- a/croff/ni.c
+++ b/croff/ni.c
@@ -1,5 +1,5 @@
 #include "tdef.h"
-static char Sccsid[] "@(#)ni.c	1.3 of 4/26/77";
+static char Sccsid[] = "@(#)ni.c  1.3 of 4/26/77";
 char obuf[OBUFSZ];
 char *obufp obuf;
 int r[NN] {'%','nl','yr','hp','ct','dn','mo','dy','dw','ln','dl','st','sb','c.'};

--- a/neqn/ne4.c
+++ b/neqn/ne4.c
@@ -6,9 +6,21 @@ int	gfont	'R';
 
 char	in[600];	/* input buffer */
 int	exit();
+int getline(char *s);
+int inline(void);
+int putout(int p1);
+int max(int i, int j);
+int oalloc(void);
+int ofree(int n);
+int setps(int p);
+int nrwid(int n1, int p, int n2);
+int setfile(int argc, char *argv[]);
+int yyerror(void);
+int init(void);
+int error(int fatal, char *s1, char *s2);
 int noeqn;
 
-main(argc,argv) int argc; char *argv[];{
+int main(int argc, char *argv[]) {
 	int i, type;
 	first = 0;
 	lefteq = righteq = '\0';

--- a/tbl/t1.c
+++ b/tbl/t1.c
@@ -11,10 +11,12 @@
 # define MACROS "cc/troff/smac"
 # endif
 
+int tbl(int argc, char **argv);
+int setinp(int argc, char **argv);
+int swapin(void);
+int badsig(void);
 # define ever (;;)
-
-main(argc,argv)
-	char *argv[];
+int main(int argc, char *argv[])
 {
 # if gcos
 if(!intss()) tabout = fopen("qq", "w"); /* default media code is type 5 */


### PR DESCRIPTION
## Summary
- modernize SCCS id declarations
- add missing prototypes
- convert K&R `main` to modern signatures

## Testing
- `make` *(fails: expected '=' or ';' in hytab.c)*