### PR TITLE
Add SSE-optimized memory routines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,18 @@ SRC_C := $(wildcard roff/*.c)
 OBJDIR := build
 OBJ := $(patsubst %.c,$(OBJDIR)/%.o,$(SRC_C))
 
+ifdef USE_SSE
+SRC_SSE := roff/sse_memops.S
+OBJ += $(patsubst %.S,$(OBJDIR)/%.o,$(SRC_SSE))
+endif
+
 all: $(OBJ)
 
 $(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR)/%.o: %.S
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/roff/sse_memops.S
+++ b/roff/sse_memops.S
@@ -1,0 +1,79 @@
+#ifdef USE_SSE
+    .text
+    .globl fast_memcpy
+    .type fast_memcpy,@function
+fast_memcpy:
+    mov %rdi, %rax        # return value = dst
+    mov %rdx, %rcx        # bytes to copy
+    shr $4, %rcx          # number of 16-byte blocks
+    jz 2f
+1:
+    movdqu (%rsi), %xmm0
+    movdqu %xmm0, (%rdi)
+    add $16, %rsi
+    add $16, %rdi
+    dec %rcx
+    jne 1b
+2:
+    mov %rdx, %rcx
+    and $15, %rcx         # tail bytes
+    jz 4f
+3:
+    movsb
+    dec %rcx
+    jne 3b
+4:
+    ret
+
+    .globl fast_memcmp
+    .type fast_memcmp,@function
+fast_memcmp:
+    test %rdx, %rdx
+    je .equal
+    mov %rdi, %r8         # p1
+    mov %rsi, %r9         # p2
+    mov %rdx, %rcx
+    shr $4, %rcx          # blocks of 16
+    jz .tail
+.loop:
+    movdqu (%r8), %xmm0
+    movdqu (%r9), %xmm1
+    pcmpeqb %xmm1, %xmm0
+    pmovmskb %xmm0, %eax
+    cmp $0xFFFF, %eax
+    jne .diff_block
+    add $16, %r8
+    add $16, %r9
+    dec %rcx
+    jne .loop
+.tail:
+    mov %rdx, %rcx
+    and $15, %rcx
+    jz .equal
+.tail_loop:
+    movzbq (%r8), %rax
+    movzbq (%r9), %rdx
+    sub %rdx, %rax
+    jne .ret
+    inc %r8
+    inc %r9
+    dec %rcx
+    jne .tail_loop
+.equal:
+    xor %eax, %eax
+.ret:
+    ret
+.diff_block:
+    movdqu (%r8), %xmm0
+    movdqu (%r9), %xmm1
+    pcmpeqb %xmm1, %xmm0
+    pmovmskb %xmm0, %eax
+    not %eax
+    bsf %eax, %eax
+    add %rax, %r8
+    add %rax, %r9
+    movzbq (%r8), %rax
+    movzbq (%r9), %rdx
+    sub %rdx, %rax
+    ret
+#endif

--- a/roff/sse_memops.h
+++ b/roff/sse_memops.h
@@ -1,0 +1,15 @@
+#ifdef USE_SSE
+#include <stddef.h>
+void *fast_memcpy(void *dst, const void *src, size_t n);
+int fast_memcmp(const void *s1, const void *s2, size_t n);
+#else
+#include <string.h>
+static inline void *fast_memcpy(void *dst, const void *src, size_t n)
+{
+    return memcpy(dst, src, n);
+}
+static inline int fast_memcmp(const void *s1, const void *s2, size_t n)
+{
+    return memcmp(s1, s2, n);
+}
+#endif


### PR DESCRIPTION
## Summary
- add assembly helpers for fast memcpy/memcmp using SSE
- compile SSE helpers when `USE_SSE` is enabled

## Testing
- `make USE_SSE=1`