### PR TITLE
Configure Git stripnul filter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,4 @@ end_of_line = lf
 trim_trailing_whitespace = false
 indent_style = tab
 tab_width = 8
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,6 @@ neqn/ne.g           linguist-language=Lex
 neqn/neqnrc         linguist-language=Shell
 
 # Normalize line endings for source files
-*.c text
-*.h text
-*.s text diff
+*.c text filter=stripnul
+*.h text filter=stripnul
+*.s text diff filter=stripnul

--- a/gitconfigure
+++ b/gitconfigure
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+# gitconfigure -- set up repository-specific Git configuration
+#
+# The script registers the stripnul filter which cleans trailing NUL
+# bytes from files. Run this after cloning the repository to enable the
+# filter for all source files.
+
+set -e
+
+# Register the filter's clean and smudge commands.
+git config filter.stripnul.clean 'tools/git-strip-nul.sh'
+git config filter.stripnul.smudge cat

--- a/tools/git-strip-nul.sh
+++ b/tools/git-strip-nul.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# git-strip-nul.sh -- remove trailing NUL bytes from input
+#
+# This script is intended for use as a Git filter. It reads data from
+# standard input, strips any NUL characters that appear at the end of
+# the stream, and writes the cleaned result to standard output. A final
+# newline is always appended so editors see a proper end of file.
+
+set -e
+
+# Use Perl for reliable byte processing. The regular expression
+# replaces one or more NUL bytes at the end of the data with a single
+# newline character.
+exec perl -0pe 's/\x00+\z/\n/'


### PR DESCRIPTION
## Summary
- keep editorconfig tidy and always newline terminate
- add a gitconfigure helper to set up repository Git settings
- add a stripnul filter script in tools
- apply the stripnul filter to C, header, and assembly files

## Testing
- `make -n`