### PR TITLE
Add Caldera license and mention in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2002, Caldera International, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+   must display the following acknowledgement:
+     This product includes software developed or owned by Caldera International, Inc.
+4. Neither the name of Caldera International, Inc. nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY CALDERA INTERNATIONAL, INC. "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CALDERA INTERNATIONAL, INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ for disassembling and fuzzing troff-based software.
 
 [1]: https://web.archive.org/web/20060823034049/http://www.tuhs.org/Archive/PDP-11/Distributions/usdl/bostic_pwb.tar.gz
 [2]: https://github.com/Alhadis/otroff/pulls
+
+License
+-------
+The contents of this repository are made available under the terms of the
+Caldera "Ancient UNIX" license released in 2002.  This permissive
+BSD-style license allows modification and redistribution so the sources
+can be modernized and built on contemporary hardware.  See the LICENSE
+file for full details.


### PR DESCRIPTION
## Summary
- add Caldera International "Ancient UNIX" license
- document the license in `README.md`

## Testing
- `make clean`
- `make` *(fails: expected tokens in `hytab.c`)*