### PR TITLE
Add missing roff8 globals

### DIFF
--- a/roff/roff8.c
+++ b/roff/roff8.c
@@ -1,17 +1,65 @@
-/* Global data inspired by the original roff8.s.  Only a very small
- * subset is represented here for demonstration purposes. */
+/*
+ * Global data translated from the original ``roff8.s`` module.  These
+ * variables provided default settings and state used throughout the
+ * formatter.  Only a subset of the original assembler data is actually
+ * utilised by the modernised sources but all initialised items are
+ * reproduced here for completeness.
+ */
 
-int slow = 1;
-int pto  = 9999;
-int po   = 0;
-int ls   = 1;
-int ls1  = 1;
-int pn   = 1;
+/* Basic runtime flags and counters */
+int slow  = 1;       /* non-zero if output should be throttled        */
+int pto   = 9999;    /* last page to process                          */
+int po    = 0;       /* page offset                                   */
+int ls    = 1;       /* line spacing                                  */
+int ls1   = 1;       /* line spacing for the first line               */
+int pn    = 1;       /* current page number                           */
 
-char ttyx[] = "/dev/tty0";
-char bfn[]  = "/tmp/rtma";
+/* Trap related margins */
+int ma1   = 2;
+int ma2   = 2;
+int ma3   = 1;
+int ma4   = 3;
 
-/* tables used by the hyphenation code */
+/* Layout parameters */
+int ll    = 65;      /* line length                                   */
+int llh   = 65;      /* line length hold area                         */
+int hx    = 1;       /* hyphenation mode                              */
+int pl    = 66;      /* page length                                   */
+int ad    = 1;       /* text adjustment flag                          */
+int fi    = 1;       /* fill mode flag                                */
+
+char cc   = '.';     /* command character                             */
+int ohc   = 200;     /* overstrike hold character                     */
+int hyf   = 1;       /* enable hyphenation                            */
+int hypedf = 0;      /* hyphenation has been used                     */
+
+char obuf[128];      /* main output buffer                            */
+char *obufp = obuf;  /* pointer into ``obuf``                         */
+
+int thresh = 240;    /* hyphenation threshold                         */
+char tabc  = '\'';   /* tab repetition character                      */
+
+/* Default tab stop positions (in character columns) */
+int tabtab[] = { 8, 16, 24, 32, 40, 48, 56, 64, 72, 0 };
+
+/* Files and strings referenced during startup */
+char suffil[] = "/usr/lib/suftab"; /* suffix table file path        */
+char ones[]   = "ixcm";             /* Roman numeral 1s table        */
+char fives[]  = "vld";              /* Roman numeral 5s table        */
+char ttyx[]   = "/dev/tty0";        /* controlling terminal device   */
+char bfn[]    = "/tmp/rtma";        /* temporary buffer file name    */
+
+int ofile  = -1;     /* output file descriptor                        */
+int nextb  = 4;      /* next available buffer                         */
+
+/*
+ * The original code kept a pointer to a list of input files in ``ilist``.
+ * The list itself is declared here purely to satisfy that dependency.
+ */
+int ilist[4];
+int *ilistp = ilist; /* pointer into ``ilist``                        */
+
+/* Hyphenation digram tables (externals provided by roff7.c) */
 extern char bxh[];
 extern char hxx[];
 extern char bxxh[];


### PR DESCRIPTION
## Summary
- port remaining global variables from `roff8.s` to `roff8.c`
- add buffer and table definitions from the assembly file
- document the purpose of each variable

## Testing
- `make roff`