### PR TITLE
Implement helper routines

### DIFF
--- a/roff/roff3.c
+++ b/roff/roff3.c
@@ -4,26 +4,66 @@
 /* Additional formatter logic originally in roff3.s.  This translation
  * implements a couple of helpers used by the request stubs. */
 
-/* Return non-zero if c is an alphabetic character. */
+/*
+ * alph -- helper matching the `alph2:` check in roff3.s.
+ *
+ * Return non-zero if c is an alphabetic character.
+ */
 int alph(int c) { return isalpha(c); }
 
-/* Convert a character to lower case. */
+/*
+ * maplow -- corresponds to the `maplow:` routine in the original code.
+ * Convert a character to lower case.
+ */
 int maplow(int c) { return tolower((unsigned char)c); }
 
-/* Placeholder for line break logic. */
-void rbreak(void) { printf("[stub] rbreak called\n"); }
-
-/* Last character fetched by skipcont().  This mimics the ``ch`` variable
- * from the original assembly sources.  */
+/*
+ * ch -- global holding a character pushed back by skipcont or getchar.
+ * In the original sources this variable was used by a number of helper
+ * routines.  We retain the name for clarity.
+ */
 int ch = 0;
 
+
+
 /*
- * Consume continuation characters following a request name.
+ * getchar -- simplified translation of the `getchar:` routine from
+ * roff1.s.  Only the pushback via `ch` is modeled here.
+ */
+#undef getchar
+int getchar(void)
+{
+  int c = ch;
+  if (c != 0) {
+    ch = 0;
+    return c;
+  }
+  return fgetc(stdin);
+}
+
+/*
+ * rbreak -- break the current output line.
  *
- * The original skipcont routine skipped over any additional
- * alphabetic characters (allowing long request names) and any
- * subsequent spaces.  The first non-space character encountered is
- * stored in ``ch`` for the caller.
+ * This corresponds to the `rbreak:` routine in roff3.s.  The original
+ * assembly performed a large amount of bookkeeping around page
+ * boundaries and output buffering.  Here we simply flush the line using
+ * the high level helper implemented in roff4.c.
+ */
+extern void nline(void); /* label `newline` in roff4.s */
+
+void rbreak(void)
+{
+  nline();
+}
+
+
+/*
+ * skipcont -- consume continuation characters following a request name.
+ *
+ * This mirrors the behaviour of the `skipcont:` routine in roff3.s.  The
+ * original skipped over additional alphabetic characters (allowing long
+ * request names) and any subsequent spaces.  The first non-space
+ * character encountered is stored in `ch` for the caller.
  */
 void skipcont(void) {
   int c;


### PR DESCRIPTION
## Summary
- implement helpers from `roff3.s`
- translate `getchar`, `skipcont` and `rbreak` and link them to assembly labels

## Testing
- `gcc -std=gnu89 -Wall -O2 -c roff/roff3.c -o /tmp/roff3.o`