### PR TITLE
Switch build to C90

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
     MARCH := $(CPU)
 endif
 
-CFLAGS ?= -std=gnu89 -Wall -O2 -march=$(MARCH)
+CFLAGS ?= -std=c90 -Wall -O2 -march=$(MARCH)
 LDFLAGS ?=
 
 # Collect source files across the project.  Only the modern C
@@ -52,10 +52,6 @@ neqn:  $(NEQN_OBJ)
 roff:  $(ROFF_OBJ)
 
 $(OBJDIR)/%.o: %.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -c $< -o $@
-
-$(OBJDIR)/%.o: %.S
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Building
 --------
 Run `./setup.sh` while network access is available to install the
 required toolchain.  Afterwards the code can be built using `make`.
-Object files are compiled with the `-std=gnu89` option so that the
-legacy sources build cleanly on modern compilers.  The target CPU can be
+Object files are compiled with the `-std=c90` option so that the legacy
+sources build cleanly on modern compilers.  The target CPU can be
 specified via the `CPU` variable, for example:
 
 ```

--- a/roff/runtime.c
+++ b/roff/runtime.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/types.h> /* defines mode_t */
 #include <sys/stat.h>
 #include <string.h>
 


### PR DESCRIPTION
## Summary
- compile with C90 instead of GNU89
- drop unused assembly build rule
- fix `runtime.c` to include `sys/types.h`
- update README for the new C standard

## Testing
- `make clean`