### PR TITLE
Add stub translations for assembly labels

### DIFF
--- a/croff/pti.c
+++ b/croff/pti.c
@@ -6,6 +6,7 @@
  * Portable translation of the historic phototypesetter interpreter
  * (pti.s).  Labels from the original assembly source are preserved
  * as comments.
+ * The entry point corresponds to the `start` label in the assembly.
  */
 
 /* .bss */

--- a/roff/roff1.c
+++ b/roff/roff1.c
@@ -146,3 +146,9 @@ static int switch_code(int c, const unsigned char *tab) {
         return tab == pfxtab ? 037 : 0;
     return p[1];
 }
+
+/*
+ * control -- stub matching the historic label `control` in roff1.s.
+ * The original parsed a request name and dispatched to a handler.
+ */
+void control(void) { puts("[stub] control"); }

--- a/roff/roff2.c
+++ b/roff/roff2.c
@@ -155,3 +155,12 @@ void casepo(void) { stub("po"); }
 void casede(void) { stub("de"); }
 void caseig(void) { stub("ig"); }
 void casemk(void) { stub("mk"); }
+
+/*
+ * need -- placeholder for the vertical spacing helper labelled `need` in
+ * roff2.s.  The real routine ensured there was room on the page before
+ * printing additional lines.
+ */
+void need(int n) {
+    (void)n; /* not implemented */
+}

--- a/roff/roff3.c
+++ b/roff/roff3.c
@@ -80,3 +80,9 @@ void skipcont(void) {
  * simply returns zero.
  */
 int number(void) { return 0; }
+
+/*
+ * donum -- simplified stand-in for the `donum` routine in roff3.s.  The
+ * original output line numbers.  This version only notes invocation.
+ */
+void donum(void) { puts("[stub] donum"); }

--- a/roff/roff4.c
+++ b/roff/roff4.c
@@ -179,3 +179,9 @@ void space(int n, int (*put)(int)) {
     while (n-- > 0)
         put(' ');
 }
+
+/*
+ * headin -- stub for the header input routine labelled `headin` in
+ * roff4.s.  The real implementation parsed header templates.
+ */
+void headin(void) { puts("[stub] headin"); }

--- a/roff/roff5.c
+++ b/roff/roff5.c
@@ -183,3 +183,12 @@ int checkvow(const char *p) {
     (void)p;
     return 0;
 }
+
+/*
+ * rdsuf -- stub representing the `rdsuf` subroutine in roff5.s which read
+ * suffix information.  This simplified version merely logs the call.
+ */
+void rdsuf(const char *name) {
+    (void)name;
+    puts("[stub] rdsuf");
+}


### PR DESCRIPTION
## Summary
- expand partial C translations with simple stubs referencing historical labels
- document assembly entry point in `pti.c`

## Testing
- `make roff`