### PR TITLE
Fix late declarations

### DIFF
--- a/roff/roff1.c
+++ b/roff/roff1.c
@@ -90,6 +90,11 @@ static void parse_args(int argc, char **argv) {
 
 /* main -- entry translated from label ``ibuf`` */
 int main(int argc, char **argv) {
+    int i; /* loop counter for table initialisation */
+    char buf[256]; /* temporary line buffer */
+    size_t pos = 0; /* current index into ``buf`` */
+    int c; /* character being processed */
+
     mesg(0); /* disable messages to tty */
     signal(SIGINT, cleanup); /* jump to ``place`` on signals */
     signal(SIGQUIT, cleanup);
@@ -102,14 +107,10 @@ int main(int argc, char **argv) {
     parse_args(argc, argv);
 
     /* build identity translation table */
-    int i;
     for (i = 0; i < 128; ++i)
         trtab[i] = (unsigned char)i;
 
     /* trivial processing loop */
-    char buf[256];
-    size_t pos = 0;
-    int c;
     while ((c = getchar()) != EOF) {
         buf[pos++] = (char)c;
         if (c == '\n' || pos >= sizeof(buf))

--- a/roff/roff4.c
+++ b/roff/roff4.c
@@ -43,6 +43,9 @@ static void output_filled(void);
  */
 void text_line(const char *s) {
     while (*s) {
+        char word[128]; /* current word extracted from input */
+        size_t wlen = 0; /* length of ``word`` */
+
         /* skip leading whitespace */
         while (*s && isspace((unsigned char)*s)) {
             if (*s == '\n')
@@ -54,8 +57,6 @@ void text_line(const char *s) {
             break;
 
         /* copy the next word */
-        char word[128];
-        size_t wlen = 0;
         while (s[wlen] && !isspace((unsigned char)s[wlen]) &&
                wlen < sizeof(word) - 1) {
             word[wlen] = s[wlen];
@@ -113,14 +114,15 @@ static void flush_line(void) {
  * routine in roff4.s.
  */
 static void adjust_line(void) {
+    size_t letters = 0; /* total number of characters in line */
+    int i; /* loop counter */
+
     fac = 0;
     fmq = 0;
 
     if (!adjust_enabled || word_count <= 1)
         return;
 
-    size_t letters = 0;
-    int i;
     for (i = 0; i < word_count; ++i)
         letters += strlen(word_list[i]);
 
@@ -138,6 +140,8 @@ static void adjust_line(void) {
  * adjust_line().  Behaviour is similar to the original fill routine.
  */
 static void output_filled(void) {
+    int i; /* index over words */
+
     if (!adjust_enabled || !fill_enabled || word_count == 0 ||
         line_len >= ROFF_LINE_WIDTH) {
         fwrite(line_buf, 1, line_len, stdout);
@@ -145,9 +149,8 @@ static void output_filled(void) {
         return;
     }
 
-    int i;
     for (i = 0; i < word_count; ++i) {
-        int j;
+        int j; /* index for padding spaces */
         fputs(word_list[i], stdout);
         if (i < word_count - 1) {
             int n = fac;

--- a/roff/roff5.c
+++ b/roff/roff5.c
@@ -126,7 +126,10 @@ static int digram(const char *start, const char *end) {
  * hyphen position was found.
  */
 int hyphenate(const char *w) {
-    const char *p = w;
+    const char *p = w; /* scanning pointer */
+    const char *start; /* start of alphabetic sequence */
+    const char *end; /* end of alphabetic sequence */
+    int pos; /* chosen hyphen position */
 
     while (*p && punct((unsigned char)*p))
         ++p;
@@ -134,10 +137,10 @@ int hyphenate(const char *w) {
     if (!*p || !alph((unsigned char)*p))
         return 0;
 
-    const char *start = p++;
+    start = p++;
     while (*p && alph((unsigned char)*p))
         ++p;
-    const char *end = p - 1;
+    end = p - 1;
 
     while (*p && punct((unsigned char)*p))
         ++p;
@@ -147,7 +150,7 @@ int hyphenate(const char *w) {
     if ((end - start) < 4)
         return 0;
 
-    int pos = suffix(start, end);
+    pos = suffix(start, end);
     if (pos == -1)
         pos = digram(start, end);
 


### PR DESCRIPTION
## Summary
- move variable declarations in `roff1.c` to top of `main`
- move declarations in `roff4.c` to top of their blocks
- relocate declarations in `roff5.c::hyphenate` and adjust initialisation

## Testing
- `make clean`
- `make roff`