### PR TITLE
Update README with binary warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ are back to October 25th, 1978.
 Building
 --------
 Run `./setup.sh` while network access is available to install the
-required toolchain.  Afterwards the code can be built using `make`.
+required toolchain.  Before building, run `./gitconfigure` once after
+cloning so that a Git filter strips trailing NUL bytes from the
+sources.  Without this step stray NUL characters can cause compilation
+to fail.  Afterwards the code can be built using `make`.
+
+Some of the historical headers such as `croff/t.h` and `croff/tdef.h`
+contain non-text data and are marked as binary in `.gitattributes`.
+Avoid editing these files directly or the PR system will reject the
+patch with a “binaries not supported” error.
 Object files are compiled with the `-std=gnu89` option so that the
 legacy sources build cleanly on modern compilers.  The target CPU can be
 specified via the `CPU` variable, for example:


### PR DESCRIPTION
## Summary
- document not editing binary headers to avoid PR failures

## Testing
- `make clean`
- `make` *(fails to compile croff sources)*