### PR TITLE
Fix char classification casts in roff utils

### DIFF
--- a/roff/hyphen_utils.c
+++ b/roff/hyphen_utils.c
@@ -2,13 +2,16 @@
 
 /* Simple helpers used by the old hyphenation code. */
 
+/*
+ * Determine if character ``c`` is punctuation.
+ */
 int punct(int c) {
     if (c == 0)
         return 0;
-    return !isalpha(c);
+    return !isalpha((unsigned char)c);
 }
 
 int vowel(int c) {
-    c = tolower(c);
+    c = tolower((unsigned char)c);
     return c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' || c == 'y';
 }

--- a/roff/roff3.c
+++ b/roff/roff3.c
@@ -9,7 +9,10 @@
  *
  * Return non-zero if c is an alphabetic character.
  */
-int alph(int c) { return isalpha(c); }
+/*
+ * Check if the provided character is alphabetic.
+ */
+int alph(int c) { return isalpha((unsigned char)c); }
 
 /*
  * maplow -- corresponds to the `maplow:` routine in the original code.
@@ -64,7 +67,7 @@ void skipcont(void) {
     int c;
 
     /* Skip over alphabetic continuation characters. */
-    while ((c = getchar()) != EOF && isalpha(c))
+    while ((c = getchar()) != EOF && isalpha((unsigned char)c))
         ;
 
     /* Consume trailing spaces. */


### PR DESCRIPTION
## Summary
- fix casts to `unsigned char` when using ctype
- run clang-format

## Testing
- `make clean`
- `make all` *(fails: croff/n1.c compile errors)*