### PR TITLE
Add header guard to sse_memops.h

### DIFF
--- a/roff/sse_memops.h
+++ b/roff/sse_memops.h
@@ -1,5 +1,11 @@
+/* Header guard to prevent multiple inclusions. */
+#ifndef SSE_MEMOPS_H
+#define SSE_MEMOPS_H
+
 #include <stddef.h>
 
 /* Prototypes for portable memory operations. */
 void *fast_memcpy(void *dst, const void *src, size_t n);
 int fast_memcmp(const void *s1, const void *s2, size_t n);
+
+#endif /* SSE_MEMOPS_H */


### PR DESCRIPTION
## Summary
- add header guard to `sse_memops.h`
- run clang-format

## Testing
- `clang-format -i roff/sse_memops.h`
- `pytest -q`