### PR TITLE
Switch mktemp to mkstemp

### DIFF
--- a/croff/n1.c
+++ b/croff/n1.c
@@ -8,10 +8,10 @@
 #include <unistd.h> /* read, write, open, close */
 #include <signal.h> /* signal */
 #include <fcntl.h> /* open flags */
+#include <stdlib.h>
 
-/* Prototypes for libc functions used without including <stdlib.h> */
+/* Prototype for exit(3) kept for historical reasons. */
 extern void exit(int);
-char *mktemp(char *);
 /*
 troff1.c
 
@@ -349,20 +349,24 @@ void init1(char a) {
         */
     memcpy(sufind, suftab_index, sizeof(sufind));
 
-    p = mktemp("/tmp/taXXXXX");
+    /* Create a temporary file using mkstemp for security. */
+    static char tmp_template[] = "/tmp/taXXXXXX";
+    int fd = mkstemp(tmp_template);
+    p = tmp_template;
     if (a == 'a')
         p = &p[5];
-    if ((close(creat(p, 0600))) < 0) {
+    if (fd < 0) {
         prstr("Cannot create temp file.\n");
         exit(-1);
     }
-    ibf = open(p, 2);
+    /* Keep the descriptor for later use. */
+    ibf = fd;
     for (i = 256; --i;)
         trtab[i] = i;
     trtab[UNPAD] = ' ';
     mchbits();
     if (a != 'a')
-        unlkp = p;
+        unlkp = tmp_template;
 }
 /*
  * Perform runtime initialization after processing command line options.

--- a/croff/n2.c
+++ b/croff/n2.c
@@ -54,6 +54,7 @@ extern int paper;
 extern int gflag;
 extern int *nxf;
 extern char *unlkp;
+extern int ibf;
 extern char *nextf[];
 extern int pipeflg;
 extern int ejf;
@@ -267,6 +268,8 @@ void done3(int x) {
     error |= x;
     signal(SIGINT, 1);
     signal(SIGKILL, 1);
+    /* Close the temporary file before unlinking it. */
+    close(ibf);
     unlink(unlkp);
 #ifdef NROFF
     twdone();


### PR DESCRIPTION
## Summary
- use `mkstemp` in `init1` for safer temp files
- close the temporary descriptor during cleanup
- include `<stdlib.h>` and remove obsolete prototype

## Testing
- `pytest -q`