### PR TITLE
Fix quoting for git filters

### DIFF
--- a/gitconfigure
+++ b/gitconfigure
@@ -8,5 +8,7 @@
 set -e
 
 # Register the filter's clean and smudge commands.
-git config filter.stripnul.clean 'tools/git-strip-nul.sh'
-git config filter.stripnul.smudge cat
+# Use an absolute path so Git always finds the script.
+git config filter.stripnul.clean "\"$(pwd)/tools/git-strip-nul.sh\""
+# Quote the smudge command as well for consistency.
+git config filter.stripnul.smudge "\"cat\""


### PR DESCRIPTION
## Summary
- quote filter commands in `gitconfigure`
- ensure Git always sees an absolute path to the stripnul script

## Testing
- `pytest -q`