### PR TITLE
Add pytest test rule and empty input test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,4 +58,8 @@ $(OBJDIR)/%.o: %.c
 clean:
 	rm -rf $(OBJDIR)
 
-.PHONY: all clean croff tbl neqn roff
+.PHONY: all clean croff tbl neqn roff test
+
+# Run the test-suite using pytest
+test:
+	pytest -q

--- a/tests/test_cmporder.py
+++ b/tests/test_cmporder.py
@@ -14,8 +14,9 @@ def run_cmporder(input_lines: list[str]) -> list[str]:
     # Path to the cmporder executable script.
     cmporder_path = Path(__file__).resolve().parents[1] / "tools" / "cmporder.py"
 
-    # Create a single string from the input lines terminated by a newline.
-    joined = "\n".join(input_lines) + "\n"
+    # Create a single string from the input lines and append a newline
+    # only when input is non-empty.
+    joined = "\n".join(input_lines) + ("\n" if input_lines else "")
 
     # Execute the cmporder script using the current Python interpreter.
     result = subprocess.run(
@@ -60,3 +61,8 @@ def test_sorted_input_unchanged() -> None:
     # cmporder should not alter the ordering of an already sorted list.
     output = run_cmporder(lines)
     assert output == lines
+
+
+def test_empty_input_returns_empty_list() -> None:
+    """Verify cmporder returns an empty list for empty input."""
+    assert run_cmporder([]) == []


### PR DESCRIPTION
## Summary
- add a `test` target to `Makefile`
- ensure cmporder doesn't add spurious newline for empty input
- test that cmporder handles empty input

## Testing
- `pytest -q`
- `make test`
