### PR TITLE
Define POSIX macro for mkstemp

### DIFF
--- a/roff/roff1.c
+++ b/roff/roff1.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200809L /* expose mkstemp */
+
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>


### PR DESCRIPTION
## Summary
- enable POSIX features in roff1 to expose `mkstemp`
- rebuild to confirm the implicit declaration warning is gone

## Testing
- `make roff`