### PR TITLE
Implement neqn ne0.c stub module

### DIFF
--- a/neqn/ne.h
+++ b/neqn/ne.h
@@ -16,7 +16,8 @@ int setps(int p);
 int nrwid(int n1, int p, int n2);
 int setfile(int argc, char *argv[]);
 int yyparse(void);
-int yyerror(void);
+/* Parser error handler defined in y.tab.c */
+void yyerror(const char *s);
 int init(void);
 int error(int fatal, char *s1, char *s2);
 int flush(int fd);
@@ -53,6 +54,7 @@ void mark(int n);
 void lineup(int n);
 void column(int type, int p1, int p2);
 void matrix(int p1, int p2);
+void neqn_module_init(void);
 typedef struct lookup_tab {
     char *name;
     char *val;

--- a/neqn/ne0.c
+++ b/neqn/ne0.c
@@ -1,0 +1,23 @@
+/**
+ * @file ne0.c
+ * @brief Placeholder module for the neqn preprocessor.
+ *
+ * The original 1977 implementation split functionality across
+ * multiple source files named ne0.c through ne6.c. The modern
+ * code base keeps these file names for historical reference.
+ * This file currently contains only a stub function so that
+ * the build system has a non-empty translation unit.
+ */
+
+#include "ne.h"
+
+/**
+ * @brief Initialize optional neqn components.
+ * @details
+ *  This function does not perform any work yet. It exists so
+ *  that ne0.c produces an object file and can be expanded in
+ *  the future without altering build rules.
+ */
+void neqn_module_init(void) {
+    /* Nothing to initialize at this time. */
+}

--- a/neqn/ne4.c
+++ b/neqn/ne4.c
@@ -23,6 +23,8 @@ int main(int argc, char *argv[]) {
     first = 0;
     lefteq = righteq = '\0';
     signal(SIGPIPE, exit);
+    /* Initialize optional modules. */
+    neqn_module_init();
     setfile(argc, argv);
 
     while ((type = getline(in)) != '\0') {
@@ -207,9 +209,9 @@ int setfile(int argc, char *argv[]) {
 }
 
 /*
- * yacc error handler.
+ * yacc error handler is provided by the generated parser
+ * implementation found in y.tab.c.
  */
-int yyerror(void) { return 0; }
 
 /*
  * Initialize global state.


### PR DESCRIPTION
## Summary
- add stub implementation in neqn/ne0.c
- reference new initialization stub from main
- align yyerror prototype with parser implementation

## Testing
- `make neqn`