### PR TITLE
Improve ack handling in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,13 +14,32 @@ fi
 # Update package lists
 apt-get update
 
-# Install apt packages for troff and development
-apt-get install -y --no-install-recommends \
-    build-essential git clang gdb valgrind afl++ \
+# Determine if the ACK compiler is already installed
+ACK_NEEDED=false
+if ! command -v ack >/dev/null 2>&1; then
+    ACK_NEEDED=true
+fi
+
+# Base packages required for building and analysis
+PKGS="build-essential git clang gdb valgrind afl++ \
     strace ltrace binutils autoconf automake libtool \
-    pkg-config groff groff-base mandoc \
-    radare2 \
-    bcpl bcpl-dev ack ack-dev
+    pkg-config groff groff-base mandoc radare2 \
+    bcpl bcpl-dev"
+
+# Install ACK packages only when missing
+if [ "$ACK_NEEDED" = true ]; then
+    PKGS="$PKGS ack ack-dev"
+fi
+
+
+# Install all required packages in one transaction
+apt-get install -y --no-install-recommends $PKGS
+
+# Verify that the ACK compiler is now available
+if ! command -v ack >/dev/null 2>&1; then
+    echo "ACK compiler is required but could not be installed." >&2
+    exit 1
+fi
 
 # Upgrade pip and install Python tooling for analysis
 python3 -m pip install --upgrade pip
@@ -30,5 +49,8 @@ python3 -m pip install capstone lief unicorn pwntools pyelftools r2pipe hexdump 
 if command -v npm >/dev/null 2>&1; then
     npm install -g troff
 fi
+
+# Build the repository using the installed toolchain
+make
 
 


### PR DESCRIPTION
## Summary
- ensure ack compiler is installed before building
- verify ack after apt installs and abort if missing
- build the repo after installing dependencies

## Testing
- `bash -n setup.sh`
- `pytest -q`
