### PR TITLE
Force clang in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-CC ?= clang
+# Use clang as the compiler. The built-in 'cc' is typically GCC which
+# yields slightly different diagnostics. Force clang unless the user
+# explicitly overrides it on the command line.
+CC := clang
 CPU ?= native
 
 # Map CPU values to 64-bit -march options

--- a/roff/hyphen_utils.c
+++ b/roff/hyphen_utils.c
@@ -1,4 +1,5 @@
 #include <ctype.h>
+#include "hyphen_utils.h"
 
 /* Simple helpers used by the old hyphenation code. */
 

--- a/roff/hyphen_utils.h
+++ b/roff/hyphen_utils.h
@@ -1,0 +1,7 @@
+#ifndef HYPHEN_UTILS_H
+#define HYPHEN_UTILS_H
+
+int punct(int c);
+int vowel(int c);
+
+#endif /* HYPHEN_UTILS_H */


### PR DESCRIPTION
## Summary
- set `CC := clang` so the Makefile always builds with clang

## Testing
- `make clean && make roff`