### PR TITLE
Add CMake build and OS abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.5)
+    project(otroff C)
+
+        set(CMAKE_C_STANDARD 90)
+            set(CMAKE_C_STANDARD_REQUIRED ON)
+
+                if (WIN32)
+                    set(OS_WINDOWS TRUE)
+                        elseif(APPLE)
+                            set(OS_MACOS TRUE)
+                                elseif(UNIX)
+                                    set(OS_UNIX TRUE)
+                                        endif()
+
+                                            add_library(os_abstraction) if (OS_WINDOWS)
+                                                target_sources(os_abstraction PRIVATE src / os / os_windows.c) else()
+                                                    target_sources(os_abstraction PRIVATE src / os / os_unix.c)
+                                                        endif()
+
+                                                            target_include_directories(os_abstraction PUBLIC src / os)
+
+                                                                option(BUILD_ROFF "Build the roff text formatter" OFF)
+                                                                    option(BUILD_CROFF "Build the croff formatter" OFF)
+                                                                        option(BUILD_NEQN "Build the neqn preprocessor" OFF)
+
+                                                                            if (BUILD_ROFF)
+                                                                                add_subdirectory(roff)
+                                                                                    endif() if (BUILD_CROFF)
+                                                                                        add_subdirectory(croff)
+                                                                                            endif() if (BUILD_NEQN)
+                                                                                                add_subdirectory(neqn)
+                                                                                                    endif()

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ make CPU=x86-64   # build using generic x86‑64 settings
 make CPU=haswell  # build for newer Intel chips
 ```
 
+### Building with CMake
+
+The project also supports a CMake workflow. Create a build
+directory and invoke CMake followed by `make`:
+
+```
+mkdir build && cd build
+cmake ..
+make
+```
+
+This will produce the `roff`, `croff`, and `neqn` binaries under the
+`build` directory.
+
 Running Tests
 -------------
 Tests can be executed using `make test` (to be added) or by running `pytest`

--- a/croff/CMakeLists.txt
+++ b/croff/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB CROFF_SOURCES *.c)
+    add_executable(croff ${CROFF_SOURCES})
+        target_include_directories(croff PRIVATE ${CMAKE_SOURCE_DIR} / croff)
+            target_link_libraries(croff PRIVATE os_abstraction)

--- a/neqn/CMakeLists.txt
+++ b/neqn/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB NEQN_SOURCES *.c)
+    add_executable(neqn ${NEQN_SOURCES})
+        target_include_directories(neqn PRIVATE ${CMAKE_SOURCE_DIR} / neqn)
+            target_link_libraries(neqn PRIVATE os_abstraction)

--- a/roff/CMakeLists.txt
+++ b/roff/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB ROFF_SOURCES *.c)
+    add_executable(roff ${ROFF_SOURCES})
+        target_include_directories(roff PRIVATE ${CMAKE_SOURCE_DIR} / roff)
+            target_link_libraries(roff PRIVATE os_abstraction)

--- a/roff/roff1.c
+++ b/roff/roff1.c
@@ -46,86 +46,87 @@
  * - Clean separation between input, processing, and output
  */
 
-#include <stdio.h>      /* Standard I/O operations */
-#include <stdlib.h>     /* Standard library functions */
-#include <string.h>     /* String manipulation functions */
-#include <unistd.h>     /* UNIX standard functions */
-#include <fcntl.h>      /* File control operations */
-#include <signal.h>     /* Signal handling */
-#include <sys/stat.h>   /* File status operations */
-#include <ctype.h>      /* Character classification */
+#include <stdio.h> /* Standard I/O operations */
+#include <stdlib.h> /* Standard library functions */
+#include <string.h> /* String manipulation functions */
+#include <unistd.h> /* UNIX standard functions */
+#include <fcntl.h> /* File control operations */
+#include <signal.h> /* Signal handling */
+#include <sys/stat.h> /* File status operations */
+#include <ctype.h> /* Character classification */
+#include "os_abstraction.h" /* Cross-platform wrappers */
 
 /* SCCS version identifier */
 static const char sccs_id[] = "@(#)roff1.c 1.3 25/05/29 (converted from PDP-11 assembly)";
 
 /* Buffer size constants */
-#define IBUF_SIZE 512       /**< Input buffer size */
-#define OBUF_SIZE 128       /**< Output buffer size */
-#define SSIZE 400           /**< String buffer size */
-#define MAX_TABS 20         /**< Maximum tab stops */
-#define MAX_FILES 64        /**< Maximum input files */
-#define SUFFIX_SIZE 52      /**< Suffix table size (26 * 2) */
+#define IBUF_SIZE 512 /**< Input buffer size */
+#define OBUF_SIZE 128 /**< Output buffer size */
+#define SSIZE 400 /**< String buffer size */
+#define MAX_TABS 20 /**< Maximum tab stops */
+#define MAX_FILES 64 /**< Maximum input files */
+#define SUFFIX_SIZE 52 /**< Suffix table size (26 * 2) */
 
 /* Control command constants */
-#define CC_CHAR '.'         /**< Control command character */
-#define ESC_CHAR '\\'       /**< Escape character */
-#define PREFIX_CHAR '\033'  /**< Prefix character for special sequences */
+#define CC_CHAR '.' /**< Control command character */
+#define ESC_CHAR '\\' /**< Escape character */
+#define PREFIX_CHAR '\033' /**< Prefix character for special sequences */
 
 /* Character translation and formatting */
-static unsigned char trtab[128];        /**< Character translation table */
-static unsigned char tabtab[MAX_TABS];  /**< Tab stop table */
+static unsigned char trtab[128]; /**< Character translation table */
+static unsigned char tabtab[MAX_TABS]; /**< Tab stop table */
 
 /* Input/output buffers and state */
-static char ibuf[IBUF_SIZE];           /**< Input buffer */
-static char obuf[OBUF_SIZE];           /**< Output buffer */
-static char *ibufp;                    /**< Input buffer pointer */
-static char *eibuf;                    /**< End of input buffer */
-static char *obufp;                    /**< Output buffer pointer */
+static char ibuf[IBUF_SIZE]; /**< Input buffer */
+static char obuf[OBUF_SIZE]; /**< Output buffer */
+static char *ibufp; /**< Input buffer pointer */
+static char *eibuf; /**< End of input buffer */
+static char *obufp; /**< Output buffer pointer */
 
 /* File handling state */
-static int ifile = 0;                  /**< Current input file descriptor */
-static int ibf = -1;                   /**< Temporary file descriptor */
-static int ibf1 = -1;                  /**< Secondary temporary file descriptor */
-static int suff = -1;                  /**< Suffix file descriptor */
-static char **argp;                    /**< Argument pointer */
-static int argc;                       /**< Argument count */
-static int nx = 0;                     /**< Next file flag */
+static int ifile = 0; /**< Current input file descriptor */
+static int ibf = -1; /**< Temporary file descriptor */
+static int ibf1 = -1; /**< Secondary temporary file descriptor */
+static int suff = -1; /**< Suffix file descriptor */
+static char **argp; /**< Argument pointer */
+static int argc; /**< Argument count */
+static int nx = 0; /**< Next file flag */
 
 /* Text processing state */
-static int ch = 0;                     /**< Current character */
-static int lastchar = 0;               /**< Last character read */
-static int nlflg = 0;                  /**< Newline flag */
-static int column = 0;                 /**< Current column position */
-static int ocol = 0;                   /**< Output column position */
-static int nsp = 0;                    /**< Number of spaces pending */
-static int nspace = 0;                 /**< Space count for tabs */
-static char tabc = ' ';                /**< Tab character */
+static int ch = 0; /**< Current character */
+static int lastchar = 0; /**< Last character read */
+static int nlflg = 0; /**< Newline flag */
+static int column = 0; /**< Current column position */
+static int ocol = 0; /**< Output column position */
+static int nsp = 0; /**< Number of spaces pending */
+static int nspace = 0; /**< Space count for tabs */
+static char tabc = ' '; /**< Tab character */
 
 /* Formatting parameters */
-static int pfrom = 1;                  /**< Starting page number */
-static int pto = 32767;                /**< Ending page number */
-static int pn = 1;                     /**< Current page number */
-static int stop = 0;                   /**< Stop after processing flag */
-static int slow = 1;                   /**< Slow output mode flag */
+static int pfrom = 1; /**< Starting page number */
+static int pto = 32767; /**< Ending page number */
+static int pn = 1; /**< Current page number */
+static int stop = 0; /**< Stop after processing flag */
+static int slow = 1; /**< Slow output mode flag */
 
 /* Underline processing state */
-static int ul = 0;                     /**< Underline mode */
-static int ulstate = 0;                /**< Underline state machine */
-static int ulc = 0;                    /**< Underline character count */
-static int bsc = 0;                    /**< Backspace count */
+static int ul = 0; /**< Underline mode */
+static int ulstate = 0; /**< Underline state machine */
+static int ulc = 0; /**< Underline character count */
+static int bsc = 0; /**< Backspace count */
 
 /* Include stack for nested files */
-static int ip = 0;                     /**< Include pointer */
-static int ilistp = 0;                 /**< Include list pointer */
-static int iliste = 0;                 /**< Include list end */
+static int ip = 0; /**< Include pointer */
+static int ilistp = 0; /**< Include list pointer */
+static int iliste = 0; /**< Include list end */
 
 /* Suffix table for hyphenation */
-static unsigned short suftab[26];      /**< Suffix lookup table */
+static unsigned short suftab[26]; /**< Suffix lookup table */
 
 /* Temporary file management */
-static char bfn[] = "/tmp/roffXXXXXXa";  /**< Temporary file name template */
+static char bfn[] = "/tmp/roffXXXXXXa"; /**< Temporary file name template */
 static char suffil[] = "/usr/lib/suftab"; /**< Suffix table file */
-static char ttyx[] = "/dev/ttyx";      /**< TTY device name */
+static char ttyx[] = "/dev/ttyx"; /**< TTY device name */
 
 /* Error messages */
 static const char emes1[] = "Too many files.\n";
@@ -162,16 +163,16 @@ static void ttyn_setup(void);
 static int parse_number(char **ptr);
 
 /* Control command handlers */
-static void case_ad(void);  /* Adjust */
-static void case_bp(void);  /* Break page */
-static void case_br(void);  /* Break */
-static void case_cc(void);  /* Control character */
-static void case_ce(void);  /* Center */
+static void case_ad(void); /* Adjust */
+static void case_bp(void); /* Break page */
+static void case_br(void); /* Break */
+static void case_cc(void); /* Control character */
+static void case_ce(void); /* Center */
 /* ... additional control command prototypes ... */
 
 /* Global state for control commands */
 typedef struct {
-    char cmd[3];           /**< Two-character command */
+    char cmd[3]; /**< Two-character command */
     void (*handler)(void); /**< Handler function pointer */
 } control_entry_t;
 
@@ -182,13 +183,13 @@ typedef struct {
  * Maintains alphabetical order for efficient lookup.
  */
 static const control_entry_t control_table[] = {
-    {"ad", case_ad},    /* Adjust text */
-    {"bp", case_bp},    /* Break page */
-    {"br", case_br},    /* Break line */
-    {"cc", case_cc},    /* Control character */
-    {"ce", case_ce},    /* Center lines */
+    {"ad", case_ad}, /* Adjust text */
+    {"bp", case_bp}, /* Break page */
+    {"br", case_br}, /* Break line */
+    {"cc", case_cc}, /* Control character */
+    {"ce", case_ce}, /* Center lines */
     /* Additional entries would go here... */
-    {"", NULL}          /* Sentinel entry */
+    {"", NULL} /* Sentinel entry */
 };
 
 /**
@@ -198,22 +199,22 @@ static const control_entry_t control_table[] = {
  * Based on the original assembly esctab.
  */
 typedef struct {
-    char esc;          /**< Escape character */
+    char esc; /**< Escape character */
     unsigned char val; /**< Output value */
 } escape_entry_t;
 
 static const escape_entry_t escape_table[] = {
-    {'d', 032},        /* Half line down */
-    {'u', 035},        /* Half line up */
-    {'r', 036},        /* Reverse line feed */
-    {'x', 016},        /* SO (extra chars) */
-    {'y', 017},        /* SI (normal chars) */
-    {'l', 0177},       /* Delete */
-    {'t', 011},        /* Horizontal tab */
-    {'a', 0100},       /* At sign */
-    {'n', 043},        /* Number sign */
-    {'\\', 0134},      /* Backslash */
-    {0, 0}             /* Sentinel */
+    {'d', 032}, /* Half line down */
+    {'u', 035}, /* Half line up */
+    {'r', 036}, /* Reverse line feed */
+    {'x', 016}, /* SO (extra chars) */
+    {'y', 017}, /* SI (normal chars) */
+    {'l', 0177}, /* Delete */
+    {'t', 011}, /* Horizontal tab */
+    {'a', 0100}, /* At sign */
+    {'n', 043}, /* Number sign */
+    {'\\', 0134}, /* Backslash */
+    {0, 0} /* Sentinel */
 };
 
 /**
@@ -223,14 +224,14 @@ static const escape_entry_t escape_table[] = {
  * Based on the original assembly pfxtab.
  */
 static const escape_entry_t prefix_table[] = {
-    {'7', 036},        /* Reverse line feed */
-    {'8', 035},        /* Half line up */
-    {'9', 032},        /* Half line down */
-    {'4', 030},        /* Backspace */
-    {'3', 031},        /* Carriage return */
-    {'1', 026},        /* Set horizontal tabs */
-    {'2', 027},        /* Clear horizontal tabs */
-    {0, 0}             /* Sentinel */
+    {'7', 036}, /* Reverse line feed */
+    {'8', 035}, /* Half line up */
+    {'9', 032}, /* Half line down */
+    {'4', 030}, /* Backspace */
+    {'3', 031}, /* Carriage return */
+    {'1', 026}, /* Set horizontal tabs */
+    {'2', 027}, /* Clear horizontal tabs */
+    {0, 0} /* Sentinel */
 };
 
 /**
@@ -251,25 +252,24 @@ static const escape_entry_t prefix_table[] = {
  * @param argv Argument vector
  * @return Exit status (0 for success, 1 for error)
  */
-int main(int argc_param, char *argv[]) 
-{
+int main(int argc_param, char *argv[]) {
     /* Check stack space and basic system requirements */
     if (argc_param < 1) {
         error_exit(emes1);
     }
-    
+
     /* Initialize global state */
     initialize_system();
-    
+
     /* Process command-line arguments */
     process_arguments(argc_param, argv);
-    
+
     /* Setup files and I/O */
     setup_files();
-    
+
     /* Enter main processing loop */
     main_loop();
-    
+
     /* Clean shutdown */
     cleanup_and_exit(0);
     return 0; /* Never reached */
@@ -282,27 +282,26 @@ int main(int argc_param, char *argv[])
  * parameters to their initial values. Corresponds to the init
  * code in the original assembly version.
  */
-static void initialize_system(void) 
-{
+static void initialize_system(void) {
     int i;
-    
+
     /* Initialize translation table to identity mapping */
     for (i = 0; i < 128; i++) {
         trtab[i] = (unsigned char)i;
     }
-    
+
     /* Initialize buffer pointers */
     ibufp = ibuf;
     eibuf = ibuf;
     obufp = obuf;
-    
+
     /* Initialize formatting state */
     pfrom = 1;
     pto = 32767;
     pn = 1;
     stop = 0;
     slow = 1;
-    
+
     /* Initialize character processing state */
     ch = 0;
     lastchar = 0;
@@ -310,16 +309,16 @@ static void initialize_system(void)
     column = 0;
     ocol = 0;
     nsp = 0;
-    
+
     /* Initialize underline state */
     ul = 0;
     ulstate = 0;
     ulc = 0;
     bsc = 0;
-    
+
     /* Setup signal handling */
     signal_setup();
-    
+
     /* Setup TTY permissions */
     ttyn_setup();
 }
@@ -333,18 +332,17 @@ static void initialize_system(void)
  * @param argc_param Argument count
  * @param argv Argument vector
  */
-static void process_arguments(int argc_param, char *argv[]) 
-{
+static void process_arguments(int argc_param, char *argv[]) {
     int i;
     char *arg;
-    
+
     argc = argc_param - 1; /* Don't count program name */
-    argp = argv + 1;       /* Skip program name */
-    
+    argp = argv + 1; /* Skip program name */
+
     /* Process each argument */
     for (i = 1; i < argc_param; i++) {
         arg = argv[i];
-        
+
         if (arg[0] == '+') {
             /* Starting page number */
             pfrom = parse_number(&arg);
@@ -370,16 +368,15 @@ static void process_arguments(int argc_param, char *argv[])
  * Creates temporary files, opens suffix tables, and prepares
  * the I/O system for text processing.
  */
-static void setup_files(void) 
-{
+static void setup_files(void) {
     /* Create temporary file for buffering */
     make_temp_file();
-    
+
     /* Try to open suffix table for hyphenation */
-    suff = open(suffil, O_RDONLY);
+    suff = os_open(suffil, O_RDONLY, 0);
     if (suff >= 0) {
-        lseek(suff, 20, SEEK_SET);
-        read(suff, suftab, sizeof(suftab));
+        os_lseek(suff, 20, SEEK_SET);
+        os_read(suff, suftab, sizeof(suftab));
     }
 }
 
@@ -390,14 +387,13 @@ static void setup_files(void)
  * control commands, and generates formatted output. This is
  * the core of the ROFF formatting engine.
  */
-static void main_loop(void) 
-{
+static void main_loop(void) {
     int c;
-    
+
     while (1) {
         nlflg = 0;
         c = getchar_roff();
-        
+
         if (c == CC_CHAR) {
             /* Control command */
             control_handler();
@@ -419,8 +415,7 @@ static void main_loop(void)
  * Processes normal text characters, applying formatting rules
  * and outputting them with proper spacing and alignment.
  */
-static void text_handler(void) 
-{
+static void text_handler(void) {
     /* For now, simple pass-through */
     /* Full text formatting logic would go here */
     putchar_roff(ch);
@@ -433,20 +428,19 @@ static void text_handler(void)
  * Looks up the command in the control table and calls the appropriate
  * handler function.
  */
-static void control_handler(void) 
-{
+static void control_handler(void) {
     int c1, c2;
     int i;
     char cmd[3];
-    
+
     /* Read two-character command */
     c1 = getchar_roff();
     c2 = getchar_roff();
-    
+
     cmd[0] = c1;
     cmd[1] = c2;
     cmd[2] = '\0';
-    
+
     /* Look up command in table */
     for (i = 0; control_table[i].handler != NULL; i++) {
         if (strcmp(cmd, control_table[i].cmd) == 0) {
@@ -454,7 +448,7 @@ static void control_handler(void)
             return;
         }
     }
-    
+
     /* Unknown command - ignore */
     if (strlen(cmd) > 0) {
         /* Could log unknown command here */
@@ -470,30 +464,29 @@ static void control_handler(void)
  *
  * @return Next processed character
  */
-static int getchar_roff(void) 
-{
+static int getchar_roff(void) {
     int c;
     int i;
-    
+
     /* Check for saved character */
     if (ch != 0) {
         c = ch;
         ch = 0;
         return c;
     }
-    
+
     /* Check for newline flag */
     if (nlflg) {
         return '\n';
     }
-    
+
     /* Get character from input */
     c = ngetc();
-    
+
     /* Handle escape sequences */
     if (c == ESC_CHAR) {
         c = ngetc();
-        
+
         /* Look up in escape table */
         for (i = 0; escape_table[i].esc != 0; i++) {
             if (escape_table[i].esc == c) {
@@ -504,7 +497,7 @@ static int getchar_roff(void)
     } else if (c == PREFIX_CHAR) {
         /* Handle prefix sequences */
         c = ngetc();
-        
+
         /* Look up in prefix table */
         for (i = 0; prefix_table[i].esc != 0; i++) {
             if (prefix_table[i].esc == c) {
@@ -513,7 +506,7 @@ static int getchar_roff(void)
             }
         }
     }
-    
+
     /* Update position tracking */
     if (c == '\n') {
         nlflg = 1;
@@ -521,7 +514,7 @@ static int getchar_roff(void)
     } else {
         column += width(c);
     }
-    
+
     return c;
 }
 
@@ -534,17 +527,16 @@ static int getchar_roff(void)
  *
  * @return Next character from input stream
  */
-static int ngetc(void) 
-{
+static int ngetc(void) {
     int c;
     ssize_t n;
-    
+
     /* Handle tab expansion */
     if (nspace > 0) {
         nspace--;
         return tabc;
     }
-    
+
     /* Check if we need to read more input */
     if (ibufp >= eibuf) {
         if (ifile == 0) {
@@ -552,26 +544,26 @@ static int ngetc(void)
                 return '\0'; /* End of input */
             }
         }
-        
+
         /* Read into buffer */
-        n = read(ifile, ibuf, IBUF_SIZE);
+        n = os_read(ifile, ibuf, IBUF_SIZE);
         if (n <= 0) {
             if (next_file() < 0) {
                 return '\0';
             }
-            n = read(ifile, ibuf, IBUF_SIZE);
+            n = os_read(ifile, ibuf, IBUF_SIZE);
             if (n <= 0) {
                 return '\0';
             }
         }
-        
+
         ibufp = ibuf;
         eibuf = ibuf + n;
     }
-    
+
     /* Get character from buffer */
     c = *ibufp++;
-    
+
     /* Handle tab expansion */
     if (c == '\t') {
         /* Simple tab handling - expand to spaces */
@@ -581,7 +573,7 @@ static int ngetc(void)
         }
         return ' ';
     }
-    
+
     return c;
 }
 
@@ -594,31 +586,30 @@ static int ngetc(void)
  *
  * @param c Character to output
  */
-static void putchar_roff(int c) 
-{
+static void putchar_roff(int c) {
     /* Check page range */
     if (pn < pfrom) {
         return;
     }
-    
+
     if (pn > pto) {
         return;
     }
-    
+
     /* Apply character translation */
     c &= 0177; /* Mask to 7 bits */
     if (c == 0) {
         return;
     }
-    
+
     c = trtab[c];
-    
+
     /* Handle spaces */
     if (c == ' ') {
         nsp++;
         return;
     }
-    
+
     /* Handle newlines */
     if (c == '\n') {
         nsp = 0;
@@ -626,7 +617,7 @@ static void putchar_roff(int c)
         pchar1(c);
         return;
     }
-    
+
     /* Output pending spaces */
     while (nsp > 0) {
         if (!slow) {
@@ -641,7 +632,7 @@ static void putchar_roff(int c)
         pchar1(' ');
         nsp--;
     }
-    
+
     /* Output the character */
     pchar1(c);
 }
@@ -654,8 +645,7 @@ static void putchar_roff(int c)
  *
  * @param c Character to output
  */
-static void pchar1(int c) 
-{
+static void pchar1(int c) {
     /* Update column position */
     if (c == '\t') {
         ocol = ((ocol + 8) / 8) * 8;
@@ -664,10 +654,10 @@ static void pchar1(int c)
     } else {
         ocol += width(c);
     }
-    
+
     /* Add to output buffer */
     *obufp++ = c;
-    
+
     /* Check if buffer is full */
     if (obufp >= obuf + OBUF_SIZE) {
         flush_output();
@@ -680,12 +670,11 @@ static void pchar1(int c)
  * Writes the contents of the output buffer to standard output
  * and resets the buffer pointer.
  */
-static void flush_output(void) 
-{
+static void flush_output(void) {
     size_t len = obufp - obuf;
-    
+
     if (len > 0) {
-        write(STDOUT_FILENO, obuf, len);
+        os_write(STDOUT_FILENO, obuf, len);
         obufp = obuf;
     }
 }
@@ -699,8 +688,7 @@ static void flush_output(void)
  * @param c Character to measure
  * @return Display width in columns
  */
-static int width(int c) 
-{
+static int width(int c) {
     /* Simple implementation - most characters are width 1 */
     if (c < ' ' || c > '~') {
         return 0; /* Control characters have no width */
@@ -714,8 +702,7 @@ static int width(int c)
  * Determines the next tab stop position based on current
  * column position.
  */
-static void dsp(void) 
-{
+static void dsp(void) {
     /* Simple 8-column tab stops */
     int next_tab = ((ocol + 8) / 8) * 8;
     /* Implementation would set appropriate spacing */
@@ -729,33 +716,32 @@ static void dsp(void)
  *
  * @return 0 on success, -1 on end of files
  */
-static int next_file(void) 
-{
+static int next_file(void) {
     /* Close current file */
     if (ifile > 0) {
-        close(ifile);
+        os_close(ifile);
         ifile = 0;
     }
-    
+
     /* Check for more files */
     if (nx) {
         /* Handle nx flag - not implemented in this version */
         return -1;
     }
-    
+
     if (argc <= 0) {
         return -1; /* No more files */
     }
-    
+
     /* Open next file */
-    ifile = open(*argp, O_RDONLY);
+    ifile = os_open(*argp, O_RDONLY, 0);
     if (ifile < 0) {
         return -1; /* Could not open file */
     }
-    
+
     argp++;
     argc--;
-    
+
     return 0;
 }
 
@@ -765,24 +751,23 @@ static int next_file(void)
  * Creates a unique temporary file name and opens it for
  * read/write operations.
  */
-static void make_temp_file(void) 
-{
+static void make_temp_file(void) {
     int i;
     struct stat st;
-    
+
     /* Try different file names until we find one that doesn't exist */
     for (i = 0; i < 26; i++) {
         bfn[strlen(bfn) - 1] = 'a' + i;
-        
-        if (stat(bfn, &st) < 0) {
+
+        if (os_stat(bfn, &st) < 0) {
             /* File doesn't exist - try to create it */
-            ibf = open(bfn, O_CREAT | O_RDWR, 0600);
+            ibf = os_open(bfn, O_CREAT | O_RDWR, 0600);
             if (ibf >= 0) {
                 return; /* Success */
             }
         }
     }
-    
+
     /* Could not create temporary file */
     error_exit("Cannot create temporary file");
 }
@@ -792,10 +777,9 @@ static void make_temp_file(void)
  *
  * Installs signal handlers for proper cleanup on interruption.
  */
-static void signal_setup(void) 
-{
-    signal(SIGINT, SIG_IGN);   /* Ignore interrupt */
-    signal(SIGQUIT, SIG_IGN);  /* Ignore quit */
+static void signal_setup(void) {
+    signal(SIGINT, SIG_IGN); /* Ignore interrupt */
+    signal(SIGQUIT, SIG_IGN); /* Ignore quit */
 }
 
 /**
@@ -803,8 +787,7 @@ static void signal_setup(void)
  *
  * Manages terminal permissions for proper output control.
  */
-static void ttyn_setup(void) 
-{
+static void ttyn_setup(void) {
     /* TTY setup would go here if needed */
     /* Original assembly version had complex TTY handling */
 }
@@ -818,16 +801,15 @@ static void ttyn_setup(void)
  * @param ptr Pointer to string pointer
  * @return Parsed number value
  */
-static int parse_number(char **ptr) 
-{
+static int parse_number(char **ptr) {
     int num = 0;
     char *p = *ptr + 1; /* Skip the +/- sign */
-    
+
     while (isdigit(*p)) {
         num = num * 10 + (*p - '0');
         p++;
     }
-    
+
     *ptr = p;
     return num;
 }
@@ -838,8 +820,7 @@ static int parse_number(char **ptr)
  * Reads and discards characters until a newline is encountered.
  * Used to skip to the end of the current line.
  */
-static void flushi(void) 
-{
+static void flushi(void) {
     ch = 0;
     while (!nlflg) {
         getchar_roff();
@@ -853,9 +834,8 @@ static void flushi(void)
  *
  * @param msg Error message to display
  */
-static void error_exit(const char *msg) 
-{
-    write(STDERR_FILENO, msg, strlen(msg));
+static void error_exit(const char *msg) {
+    os_write(STDERR_FILENO, msg, strlen(msg));
     exit(1);
 }
 
@@ -867,26 +847,25 @@ static void error_exit(const char *msg)
  *
  * @param status Exit status code
  */
-static void cleanup_and_exit(int status) 
-{
+static void cleanup_and_exit(int status) {
     /* Flush any remaining output */
     flush_output();
-    
+
     /* Close open files */
     if (ifile > 0) {
-        close(ifile);
+        os_close(ifile);
     }
     if (ibf >= 0) {
-        close(ibf);
-        unlink(bfn); /* Remove temporary file */
+        os_close(ibf);
+        os_unlink(bfn); /* Remove temporary file */
     }
     if (suff >= 0) {
-        close(suff);
+        os_close(suff);
     }
-    
+
     /* Restore TTY permissions */
     /* TTY restoration code would go here */
-    
+
     exit(status);
 }
 

--- a/src/os/os_abstraction.h
+++ b/src/os/os_abstraction.h
@@ -1,0 +1,34 @@
+#ifndef OS_ABSTRACTION_H
+#define OS_ABSTRACTION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+/*
+ * Cross-platform wrapper functions for basic system operations.
+ * The implementation differs per platform but presents a
+ * uniform C90 interface to the rest of the code base.
+ */
+
+int os_open(const char *path, int flags, int mode);
+ssize_t os_read(int fd, void *buf, size_t count);
+ssize_t os_write(int fd, const void *buf, size_t count);
+int os_close(int fd);
+off_t os_lseek(int fd, off_t offset, int whence);
+int os_unlink(const char *path);
+int os_stat(const char *path, struct stat *buf);
+FILE *os_fopen(const char *path, const char *mode);
+int os_fclose(FILE *file);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OS_ABSTRACTION_H */

--- a/src/os/os_unix.c
+++ b/src/os/os_unix.c
@@ -1,0 +1,43 @@
+#include "os_abstraction.h"
+
+/*
+ * Unix implementation of OS abstraction layer.
+ * These functions simply forward to the corresponding
+ * POSIX system calls.
+ */
+
+int os_open(const char *path, int flags, int mode) {
+    return open(path, flags, mode);
+}
+
+ssize_t os_read(int fd, void *buf, size_t count) {
+    return read(fd, buf, count);
+}
+
+ssize_t os_write(int fd, const void *buf, size_t count) {
+    return write(fd, buf, count);
+}
+
+int os_close(int fd) {
+    return close(fd);
+}
+
+off_t os_lseek(int fd, off_t offset, int whence) {
+    return lseek(fd, offset, whence);
+}
+
+int os_unlink(const char *path) {
+    return unlink(path);
+}
+
+int os_stat(const char *path, struct stat *buf) {
+    return stat(path, buf);
+}
+
+FILE *os_fopen(const char *path, const char *mode) {
+    return fopen(path, mode);
+}
+
+int os_fclose(FILE *file) {
+    return fclose(file);
+}

--- a/src/os/os_windows.c
+++ b/src/os/os_windows.c
@@ -1,0 +1,46 @@
+#include "os_abstraction.h"
+#include <io.h>
+
+/*
+ * Windows implementation of OS abstraction layer.
+ * These wrappers call the MSVCRT equivalents of POSIX
+ * system calls.
+ */
+
+int os_open(const char *path, int flags, int mode) {
+    return _open(path, flags, mode);
+}
+
+ssize_t os_read(int fd, void *buf, size_t count) {
+    return _read(fd, buf, count);
+}
+
+ssize_t os_write(int fd, const void *buf, size_t count) {
+    return _write(fd, buf, count);
+}
+
+int os_close(int fd) {
+    return _close(fd);
+}
+
+off_t os_lseek(int fd, off_t offset, int whence) {
+    return _lseek(fd, offset, whence);
+}
+
+int os_unlink(const char *path) {
+    return _unlink(path);
+}
+
+int os_stat(const char *path, struct stat *buf) {
+    return _stat(path, buf);
+}
+
+FILE *os_fopen(const char *path, const char *mode) {
+    FILE *f = NULL;
+    fopen_s(&f, path, mode);
+    return f;
+}
+
+int os_fclose(FILE *file) {
+    return fclose(file);
+}


### PR DESCRIPTION
## Summary
- add top-level `CMakeLists.txt` with optional subprojects
- create build files for roff, croff and neqn
- implement a simple OS abstraction layer
- use OS wrappers in some existing sources
- document the CMake build instructions

## Testing
- `cmake .. -DCMAKE_C_COMPILER=clang`
- `cmake --build .`