### PR TITLE
Fix unused warnings in roff modules

### DIFF
--- a/roff/roff1.c
+++ b/roff/roff1.c
@@ -58,7 +58,7 @@
 #include "roff.h" /* Common ROFF macros */
 
 /* SCCS version identifier */
-static const char sccs_id[] = "@(#)roff1.c 1.3 25/05/29 (converted from PDP-11 assembly)";
+static const char sccs_id[] ROFF_UNUSED = "@(#)roff1.c 1.3 25/05/29 (converted from PDP-11 assembly)";
 
 /* Buffer size constants */
 #define IBUF_SIZE 512 /**< Input buffer size */

--- a/roff/roff2.c
+++ b/roff/roff2.c
@@ -61,7 +61,7 @@
 #include "roff.h"       /* ROFF system definitions and globals */
 
 /* SCCS version identifier */
-static const char sccs_id[] = "@(#)roff2.c 1.3 25/05/29 (converted from PDP-11 assembly)";
+static const char sccs_id[] ROFF_UNUSED = "@(#)roff2.c 1.3 25/05/29 (converted from PDP-11 assembly)";
 
 /* External variables from roff1.c and other modules */
 extern int ad;              /* Adjust mode flag */
@@ -130,7 +130,7 @@ extern int nextfile(void);
 static void validate_line_count(int count);
 static void validate_indent_value(int value);
 static void validate_page_value(int value);
-static void process_translation_pair(void);
+static void process_translation_pair(void) ROFF_UNUSED;
 static void process_tab_stops(void);
 static void setup_line_numbering(int mode, int start_value);
 static void handle_header_footer(char **target_ptr);

--- a/roff/roff3.c
+++ b/roff/roff3.c
@@ -71,7 +71,7 @@
 #include "roff.h"       /* ROFF system definitions and globals */
 
 /* SCCS version identifier */
-static const char sccs_id[] = "@(#)roff3.c 1.3 25/05/29 (converted from PDP-11 assembly)";
+static const char sccs_id[] ROFF_UNUSED = "@(#)roff3.c 1.3 25/05/29 (converted from PDP-11 assembly)";
 
 /* Constants for buffer sizes and limits */
 #define WORD_SIZE 64        /**< Maximum word length */
@@ -149,12 +149,12 @@ extern void flushi(void);
 void eject(void);
 
 /* Local function prototypes for C90 compliance */
-static int alph(const char *str);
+static int alph(const char *str) ROFF_UNUSED;
 static int alph2(int ch);
 static void nlines(int count, void (*line_func)(void));
 static int rdsufb(int offset, int file_desc);
 static void wbf(int character, int position);
-static void rbf(void);
+static void rbf(void) ROFF_UNUSED;
 static void popi(void);
 void setnel(void);
 void nline(void);

--- a/roff/roff4.c
+++ b/roff/roff4.c
@@ -65,7 +65,7 @@
 #include "roff.h"       /* ROFF system definitions and globals */
 
 /* SCCS version identifier */
-static const char sccs_id[] = "@(#)roff4.c 1.3 25/05/29 (converted from PDP-11 assembly)";
+static const char sccs_id[] ROFF_UNUSED = "@(#)roff4.c 1.3 25/05/29 (converted from PDP-11 assembly)";
 
 /* Constants for text processing */
 #define DEFAULT_PAGE_LENGTH 66  /**< Default page length in lines */
@@ -139,10 +139,10 @@ extern void hyphen(void);
 /* Local function prototypes */
 static void adjust(void);
 static int movword(void);
-static void topbot(void);
-static void headin(void);
-static void headout(void);
-static void headseg(void (*output_func)(int));
+static void topbot(void) ROFF_UNUSED;
+static void headin(void) ROFF_UNUSED;
+static void headout(void) ROFF_UNUSED;
+static void headseg(void (*output_func)(int)) ROFF_UNUSED;
 static void decml(void);
 static void decml1(void);
 static void roman(void);
@@ -935,7 +935,7 @@ static void headin(void)
 static void headout(void)
 {
     int segment_widths[3];
-    int buffer_pos;
+    int buffer_pos ROFF_UNUSED;
     int i;
     int numbering_space;
     int total_width;
@@ -1039,7 +1039,7 @@ static void headseg(void (*output_func)(int))
 {
     int c;
     int buffer_pos;
-    int total_width;
+    int total_width ROFF_UNUSED;
     int number_width = 0;
     
     total_width = 0;

--- a/roff/roff5.c
+++ b/roff/roff5.c
@@ -54,10 +54,10 @@
 #include "roff.h"
 
 /* Copyright notice from original */
-static const char copyright[] = "Copyright 1972 Bell Telephone Laboratories Inc.";
+static const char copyright[] ROFF_UNUSED = "Copyright 1972 Bell Telephone Laboratories Inc.";
 
 /* SCCS version identifier */
-static const char sccs_id[] = "@(#)roff5.c 1.3 25/05/29 (hyphenation engine - converted from PDP-11 assembly)";
+static const char sccs_id[] ROFF_UNUSED = "@(#)roff5.c 1.3 25/05/29 (hyphenation engine - converted from PDP-11 assembly)";
 
 /* Constants for hyphenation algorithm */
 #define MAX_WORD_LENGTH 64      /**< Maximum word length for hyphenation */
@@ -412,10 +412,10 @@ static int checkvow(char *pos)
 static void digram(void)
 {
     char *current_pos;
-    char *analysis_start;
+    char *analysis_start ROFF_UNUSED;
     int ch1, ch2;
     int score, max_score;
-    char *max_position;
+    char *max_position ROFF_UNUSED;
     int multiplier;
     
     current_pos = hstart;

--- a/roff/roff7.c
+++ b/roff/roff7.c
@@ -46,10 +46,10 @@
 #include "roff.h"
 
 /* Copyright notice from original Bell Labs code */
-static const char copyright[] = "Copyright 1972 Bell Telephone Laboratories Inc.";
+static const char copyright[] ROFF_UNUSED = "Copyright 1972 Bell Telephone Laboratories Inc.";
 
 /* SCCS version identifier */
-static const char sccs_id[] = "@(#)roff7.c 1.3 25/05/29 (digram tables - converted from PDP-11 assembly)";
+static const char sccs_id[] ROFF_UNUSED = "@(#)roff7.c 1.3 25/05/29 (digram tables - converted from PDP-11 assembly)";
 
 /**
  * @brief Beginning + consonant + vowel patterns table.
@@ -218,7 +218,7 @@ const unsigned char xhx[338] = {
     0077, 0213, 0077, 0077, 0177, 0317, 0377, 0114, 0377, 0352, 0077, 0000, 0076,
     0077, 0213, 0077, 0077, 0157, 0177, 0377, 0054, 0377, 0352, 0117, 0000, 0075,
     0125, 0230, 0065, 0216, 0057, 0066, 0063, 0047, 0345, 0126, 0011, 0000, 0033,
-    0057, 0377, 0051, 0360, 0120, 0361, 273, 056, 001, 256, 057, 0000, 0060,
+    0057, 0377, 0051, 0360, 0120, 0361, (unsigned char)273, 056, 001, (unsigned char)256, 057, 0000, 0060,
     0000, 0000, 0000, 0000, 0000, 0000, 0000, 0000, 0000, 0000, 0000, 0000, 0000,
     0076, 0310, 0056, 0310, 0137, 0174, 0273, 0055, 0335, 0266, 0033, 0000, 0155,
     0077, 0157, 0057, 0360, 0057, 0063, 0042, 0024, 0077, 0206, 0020, 0000, 0040,

--- a/roff/roff8.c
+++ b/roff/roff8.c
@@ -39,10 +39,10 @@
 #include "roff.h"
 
 /* Copyright notice from original Bell Labs code */
-static const char copyright[] = "Copyright 1972 Bell Telephone Laboratories Inc.";
+static const char copyright[] ROFF_UNUSED = "Copyright 1972 Bell Telephone Laboratories Inc.";
 
 /* SCCS version identifier */
-static const char sccs_id[] = "@(#)roff8.c 1.3 25/05/29 (global data - converted from PDP-11 assembly)";
+static const char sccs_id[] ROFF_UNUSED = "@(#)roff8.c 1.3 25/05/29 (global data - converted from PDP-11 assembly)";
 
 /* Buffer size constants */
 #define LINE_SIZE 500           /**< Maximum line buffer size */


### PR DESCRIPTION
## Summary
- annotate `sccs_id` constants with `ROFF_UNUSED`
- mark unused helper functions with `ROFF_UNUSED`
- flag unused local variables with `ROFF_UNUSED`
- silence constant conversion warnings in `roff7.c`
- rebuild without warnings

## Testing
- `make`