### PR TITLE
Fix relative point size handling

### DIFF
--- a/croff/n6.c
+++ b/croff/n6.c
@@ -279,7 +279,15 @@ void setps(void)
         second_digit = (ch = getch() & CMASK) - '0';
         if ((second_digit >= 0) && (second_digit <= 9)) {
             ch = 0;
-            /* TODO: Apply relative change to current point size */
+            /* Adjust current point size by the relative amount */
+            point_size = pts;
+            if (first_char == '+') {
+                point_size += second_digit;
+            } else {
+                point_size -= second_digit;
+            }
+            pts = point_size;
+            mchbits();
             return;
         }
     }


### PR DESCRIPTION
## Summary
- implement handling for `+n` and `-n` point-size changes in `setps`
- keep absolute size parsing intact

## Testing
- `clang -c croff/n6.c -o /tmp/n6.o`
- `for c in croff/*.c; do clang -c $c -o build/croff/$(basename $c .c).o || exit 1; done`
- `make test`