### PR TITLE
Add format target and document stub implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,15 @@ meson:
 
 # Run the test-suite using pytest
 test:
-	pytest -q
+        pytest -q
+
+# Format all C and header files using clang-format
+.PHONY: format
+format:
+        @echo "Running clang-format..."
+        @if command -v clang-format >/dev/null 2>&1; then \
+                find roff croff neqn tbl src -name '*.c' -o -name '*.h' | \
+                xargs clang-format -i; \
+        else \
+                echo "clang-format not available"; \
+        fi

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Running Tests
 Tests can be executed using `make test` (to be added) or by running `pytest`
 directly. Both approaches run the suite located under the `tests` directory.
 
+Code Formatting
+---------------
+Run `make format` to apply `clang-format` across all C and header files. This
+ensures a consistent style throughout the project.
+
 Building individual components
 ------------------------------
 Subprojects can be compiled separately by invoking dedicated make

--- a/neqn/test_neqn.c
+++ b/neqn/test_neqn.c
@@ -17,166 +17,174 @@ static int tests_run = 0;
 static int tests_passed = 0;
 
 /* Test macros */
-#define TEST_START() do { tests_run++; printf("Running test: %s... ", __func__); } while(0)
-#define TEST_PASS() do { tests_passed++; printf("PASS\n"); } while(0)
-#define TEST_FAIL(msg) do { printf("FAIL: %s\n", msg); } while(0)
-#define TEST_ASSERT(cond) do { if (!(cond)) { TEST_FAIL(#cond); return; } } while(0)
+#define TEST_START()                              \
+    do {                                          \
+        tests_run++;                              \
+        printf("Running test: %s... ", __func__); \
+    } while (0)
+#define TEST_PASS()       \
+    do {                  \
+        tests_passed++;   \
+        printf("PASS\n"); \
+    } while (0)
+#define TEST_FAIL(msg)             \
+    do {                           \
+        printf("FAIL: %s\n", msg); \
+    } while (0)
+#define TEST_ASSERT(cond)     \
+    do {                      \
+        if (!(cond)) {        \
+            TEST_FAIL(#cond); \
+            return;           \
+        }                     \
+    } while (0)
 
 /* Test functions */
-static void test_neqn_init(void)
-{
+static void test_neqn_init(void) {
     TEST_START();
-    
+
     /* Test initialization */
     TEST_ASSERT(neqn_init() == NEQN_SUCCESS);
-    
+
     /* Test double initialization (should succeed) */
     TEST_ASSERT(neqn_init() == NEQN_SUCCESS);
-    
+
     TEST_PASS();
 }
 
-static void test_neqn_version(void)
-{
+static void test_neqn_version(void) {
     TEST_START();
-    
+
     const char *version = neqn_get_version();
     TEST_ASSERT(version != NULL);
     TEST_ASSERT(strlen(version) > 0);
-    
+
     printf("(version: %s) ", version);
     TEST_PASS();
 }
 
-static void test_context_creation(void)
-{
+static void test_context_creation(void) {
     neqn_context_t *context;
-    
+
     TEST_START();
-    
+
     /* Test context creation */
     context = neqn_context_create();
     TEST_ASSERT(context != NULL);
-    
+
     /* Test context destruction */
     neqn_context_destroy(context);
-    
+
     TEST_PASS();
 }
 
-static void test_token_creation(void)
-{
+static void test_token_creation(void) {
     neqn_token_t *token;
-    
+
     TEST_START();
-    
+
     /* Test token creation */
     token = neqn_token_create(NEQN_TOKEN_IDENTIFIER, "test", 4);
     TEST_ASSERT(token != NULL);
     TEST_ASSERT(token->type == NEQN_TOKEN_IDENTIFIER);
     TEST_ASSERT(strcmp(token->text, "test") == 0);
     TEST_ASSERT(token->length == 4);
-    
+
     /* Test token destruction */
     neqn_token_destroy(token);
-    
+
     TEST_PASS();
 }
 
-static void test_node_creation(void)
-{
+static void test_node_creation(void) {
     neqn_node_t *node;
-    
+
     TEST_START();
-    
+
     /* Test node creation */
     node = neqn_node_create(NEQN_NODE_IDENTIFIER, "variable");
     TEST_ASSERT(node != NULL);
     TEST_ASSERT(node->type == NEQN_NODE_IDENTIFIER);
     TEST_ASSERT(strcmp(node->content, "variable") == 0);
-    
+
     /* Test node destruction */
     neqn_node_destroy(node);
-    
+
     TEST_PASS();
 }
 
-static void test_utility_functions(void)
-{
+static void test_utility_functions(void) {
     char *dup_str;
     char buffer[100];
-    
+
     TEST_START();
-    
+
     /* Test string duplication */
     dup_str = neqn_strdup("hello");
     TEST_ASSERT(dup_str != NULL);
     TEST_ASSERT(strcmp(dup_str, "hello") == 0);
     free(dup_str);
-    
+
     /* Test safe string concatenation */
     strcpy(buffer, "hello");
     TEST_ASSERT(neqn_strcat_safe(buffer, " world", sizeof(buffer)) == NEQN_SUCCESS);
     TEST_ASSERT(strcmp(buffer, "hello world") == 0);
-    
+
     /* Test hash function */
     TEST_ASSERT(neqn_hash_string("test") == neqn_hash_string("test"));
-    
+
     TEST_PASS();
 }
 
-static void test_error_handling(void)
-{
+static void test_error_handling(void) {
     neqn_context_t *context;
-    
+
     TEST_START();
-    
+
     context = neqn_context_create();
     TEST_ASSERT(context != NULL);
-    
+
     /* Test error reporting */
     neqn_error(context, NEQN_ERROR_SYNTAX, "Test error message");
     TEST_ASSERT(context->error_count == 1);
-    
+
     /* Test warning reporting */
     neqn_warning(context, "Test warning message");
     TEST_ASSERT(context->warning_count == 1);
-    
+
     neqn_context_destroy(context);
-    
+
     TEST_PASS();
 }
 
-static void test_basic_processing(void)
-{
+static void test_basic_processing(void) {
     neqn_context_t *context;
     int result;
-    
+
     TEST_START();
-    
+
     context = neqn_context_create();
     TEST_ASSERT(context != NULL);
-    
+
     /* Test processing a simple line */
     result = neqn_process_line(context, "x + y");
     TEST_ASSERT(result == NEQN_SUCCESS);
-    
+
     neqn_context_destroy(context);
-    
+
     TEST_PASS();
 }
 
 /* Main test runner */
-int main(void)
-{
+int main(void) {
     printf("Starting neqn test suite...\n\n");
-    
+
     /* Initialize neqn system for testing */
     if (neqn_init() != NEQN_SUCCESS) {
         printf("Failed to initialize neqn system\n");
         return EXIT_FAILURE;
     }
-    
+
     /* Run all tests */
     test_neqn_init();
     test_neqn_version();
@@ -186,13 +194,13 @@ int main(void)
     test_utility_functions();
     test_error_handling();
     test_basic_processing();
-    
+
     /* Print results */
     printf("\nTest Results:\n");
     printf("  Tests run: %d\n", tests_run);
     printf("  Tests passed: %d\n", tests_passed);
     printf("  Tests failed: %d\n", tests_run - tests_passed);
-    
+
     if (tests_passed == tests_run) {
         printf("  All tests PASSED!\n");
         return EXIT_SUCCESS;

--- a/src/stubs.c
+++ b/src/stubs.c
@@ -2,15 +2,42 @@
 #include <stdio.h>
 
 /* Stub implementations generated for missing PDP-11 assembly functions */
+
+/* Placeholder get character; returns EOF until implemented. */
 int getchar_roff(void) { return EOF; }
+
+/* Placeholder put character; currently discards output. */
 void putchar_roff(int c) { (void)c; }
+
+/* Flush input stream; no-op stub. */
 void flushi(void) {}
+
+/* Write top and bottom margins; not implemented. */
 void topbot(void) {}
+
+/* Process header at input; stub ignoring pointer. */
 void headin(char **p) { (void)p; }
+
+/* Output header; stub ignoring pointer. */
 void headout(char **p) { (void)p; }
-void nlines(int count, int spacing) { (void)count; (void)spacing; }
+
+/* Set the number of lines and spacing; stub. */
+void nlines(int count, int spacing) {
+    (void)count;
+    (void)spacing;
+}
+
+/* Switch to next input file; stub returns 0 to signal end. */
 int nextfile(void) { return 0; }
+
+/* Read character with roff semantics; stub returns EOF. */
 int gettchar(void) { return EOF; }
+
+/* Flush output; stub performs no work. */
 void flush(void) {}
+
+/* Determine if character is alphabetic. */
 int alph(int c) { return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'); }
+
+/* Secondary alphabetic check alias. */
 int alph2(int c) { return alph(c); }


### PR DESCRIPTION
## Summary
- document stub functions in `src/stubs.c`
- add `make format` rule for `clang-format`
- clean trailing whitespace in `neqn/test_neqn.c`
- document `make format` usage in README

## Testing
- `pytest -q`