### PR TITLE
Remove stub duplicates and format stubs.c

### DIFF
--- a/src/stubs.c
+++ b/src/stubs.c
@@ -349,44 +349,12 @@ void flush(void) {
 /** Determine if a character is alphabetic. */
 int alph(int c) { return isalpha(c) != 0; }
 
-/** Extended alphabetic test used by skipcont. */
-/* Stub implementations generated for missing PDP-11 assembly functions */
-
-/* Placeholder get character; returns EOF until implemented. */
-int getchar_roff(void) { return EOF; }
-
-/* Placeholder put character; currently discards output. */
-void putchar_roff(int c) { (void)c; }
-
-/* Flush input stream; no-op stub. */
-void flushi(void) {}
-
-/* Write top and bottom margins; not implemented. */
-void topbot(void) {}
-
-/* Process header at input; stub ignoring pointer. */
-void headin(char **p) { (void)p; }
-
-/* Output header; stub ignoring pointer. */
-void headout(char **p) { (void)p; }
-
-/* Set the number of lines and spacing; stub. */
-void nlines(int count, int spacing) {
-    (void)count;
-    (void)spacing;
-}
-
-/* Switch to next input file; stub returns 0 to signal end. */
-int nextfile(void) { return 0; }
-
-/* Read character with roff semantics; stub returns EOF. */
-int gettchar(void) { return EOF; }
-
-/* Flush output; stub performs no work. */
-void flush(void) {}
-
-/* Determine if character is alphabetic. */
-int alph(int c) { return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'); }
-
-/* Secondary alphabetic check alias. */
+/**
+ * Extended alphabetic check used by skipcont.
+ *
+ * The original assembly routine provided two entry points: alph and
+ * alph2.  The latter simply called alph after loading the character
+ * into a register.  Here we provide the same functionality in C by
+ * aliasing alph2 to alph.
+ */
 int alph2(int c) { return alph(c); }


### PR DESCRIPTION
## Summary
- remove leftover stub implementations from `src/stubs.c`
- keep `alph` and `alph2` implementations only
- run clang-format on the updated file

## Testing
- `pytest -q`