### PR TITLE
Refactor header for roff modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ if(BUILD_NEQN)
 endif()
 
 # Build troff executable from roff sources
-file(GLOB ROFF_SRC CONFIGURE_DEPENDS "roff/*.c")
+file(GLOB ROFF_SRC CONFIGURE_DEPENDS "roff/*.c" "roff/*.cpp")
 add_executable(troff ${ROFF_SRC})
+
 # Enable warnings and optimization
 target_compile_options(troff PRIVATE -Wall -O2)

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,30 @@
-# Use clang as the compiler. The built-in 'cc' is typically GCC which
-# yields slightly different diagnostics. Force clang unless the user
-# explicitly overrides it on the command line.
-CC := clang
-CXX := clang++
-CPU ?= native
+#Use clang as the compiler.The built - in 'cc' is typically GCC which
+#yields slightly different diagnostics.Force clang unless the user
+#explicitly overrides it on the command line.
+CC : = clang
+         CXX : = clang++ CPU ? = native
 
-# Map CPU values to 64-bit -march options
-ifeq ($(CPU),x86-64)
-    MARCH := x86-64
-else ifeq ($(CPU),haswell)
-    MARCH := haswell
-else
-    MARCH := $(CPU)
-endif
+#Map CPU values to 64 - bit - march options
+                               ifeq($(CPU), x86 - 64)
+                                   MARCH
+                             : = x86 - 64 else ifeq($(CPU), haswell)
+                                           MARCH : = haswell else MARCH : = $(CPU)
+                                                                              endif
 
-CFLAGS ?= -std=c23 -Wall -O2 -march=$(MARCH) -fopenmp=libgomp -Isrc/os
-CXXFLAGS ?= -std=c++23 -Wall -O2 -march=$(MARCH)
-LDFLAGS ?= -fopenmp=libgomp
+                                                                                  CFLAGS
+                                                                          ? = -std = c23 - Wall - O2 - march = $(MARCH) - fopenmp = libgomp - Isrc / os
+                                                                                                                                                         CXXFLAGS
+                                                                            ? = -std = c++ 23 - Wall - O2 - march = $(MARCH)
+                                                                                                                            LDFLAGS
+                                                                                                                        ? = -fopenmp = libgomp
 
-# Collect source files across the project.  Only the modern C
-# replacements located under `roff/` are built.
-# Source files for each project directory
-# Automatically collect all modern C implementations and ignore the
-# historical PDP-11 assembly sources (*.s).
-ROFF_SRC := $(sort $(wildcard roff/*.c))
+#Collect source files across the project.Only the modern C
+#replacements located under `roff /` are built.
+#Source files for each project directory
+#Automatically collect all modern C implementations and ignore the
+#historical PDP - 11 assembly sources(*.s).
+                                                                                                                              ROFF_SRC
+                                                                                                                        : = $(sort $(wildcard roff/*.c) $(wildcard roff/*.cpp))
 # Operating-system abstraction layer sources
 OS_SRC   := src/os/os_unix.c
 STUBS_SRC := src/stubs.c

--- a/roff/CMakeLists.txt
+++ b/roff/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Build the roff formatter
-file(GLOB ROFF_SOURCES *.c)
+file(GLOB ROFF_SOURCES *.c *.cpp)
 add_executable(roff ${ROFF_SOURCES})
 # Include headers from the roff directory
 target_include_directories(roff PRIVATE ${CMAKE_SOURCE_DIR}/roff)

--- a/roff/roff1.cpp
+++ b/roff/roff1.cpp
@@ -56,6 +56,7 @@
 #include <ctype.h> /* Character classification */
 #include "os_abstraction.h" /* Cross-platform wrappers */
 #include "roff.h" /* Common ROFF macros */
+#include "roff_globals.hpp" /* Shared globals and prototypes */
 
 /* SCCS version identifier */
 static const char sccs_id[] ROFF_UNUSED = "@(#)roff1.c 1.3 25/05/29 (converted from PDP-11 assembly)";
@@ -160,13 +161,7 @@ static void signal_setup(void);
 static void ttyn_setup(void);
 static int parse_number(char **ptr);
 
-/* Control command handlers */
-static void case_ad(void); /* Adjust */
-static void case_bp(void); /* Break page */
-static void case_br(void); /* Break */
-static void case_cc(void); /* Control character */
-static void case_ce(void); /* Center */
-/* ... additional control command prototypes ... */
+/* Control command handlers provided in roff2.cpp */
 
 /* Global state for control commands */
 typedef struct {
@@ -855,10 +850,4 @@ static void cleanup_and_exit(int status) {
     exit(status);
 }
 
-/* Placeholder implementations for control command handlers */
-static void case_ad(void) { /* Adjust command */ }
-static void case_bp(void) { /* Break page command */ }
-static void case_br(void) { /* Break command */ }
-static void case_cc(void) { /* Control character command */ }
-static void case_ce(void) { /* Center command */ }
-/* Additional control command handlers would be implemented here */
+/* Control command handlers are implemented in roff2.cpp */

--- a/roff/roff_globals.hpp
+++ b/roff/roff_globals.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "roff.h"
+#include "os_abstraction.h"
+#include <cstddef>
+
+// Global variables defined in roff8.c
+extern int ad; // Adjust mode flag
+extern int fi; // Fill mode flag
+extern int ce; // Center lines count
+extern int ls; // Line spacing
+extern int ls1; // Saved line spacing
+extern int in; // Indent value
+extern int un; // Temporary indent
+extern int ll; // Line length
+extern int pl; // Page length
+extern int pn; // Page number
+extern int skip; // Skip lines count
+extern int ul; // Underline count
+extern int nl; // Current line number
+extern int nn; // Line numbering skip
+extern int ni; // Line number indent
+extern int po; // Page offset
+extern int ma1; // Margin 1
+extern int ma2; // Margin 2
+extern int ma3; // Margin 3
+extern int ma4; // Margin 4
+extern int numbmod; // Line numbering mode
+extern int lnumber; // Line number
+extern int jfomod; // Justification mode
+extern int ro; // Read-only mode
+extern int nx; // Next file flag
+extern int hx; // Header/footer flag
+extern int hyf; // Hyphenation flag
+extern int ohc; // Output hyphenation character
+extern int tabc; // Tab character
+extern int nlflg; // Newline flag
+extern int ch; // Current character
+extern int skp; // Skip processing flag
+extern int ip; // Include pointer
+extern int nextb; // Next buffer pointer
+extern char cc; // Control character
+extern char *ehead; // Even header
+extern char *efoot; // Even footer
+extern char *ohead; // Odd header
+extern char *ofoot; // Odd footer
+extern char nextf[]; // Next file name buffer
+extern char bname[]; // Buffer name
+extern unsigned char trtab[]; // Translation table
+extern unsigned char tabtab[]; // Tab table
+extern int ilist[]; // Include list
+extern int *ilistp; // Include list pointer
+
+// Functions shared across modules
+void rbreak();
+void eject();
+void need(int lines);
+void need2(int lines);
+void nlines(int count, int spacing);
+void topbot();
+void skipcont();
+void flushi();
+int getchar_roff();
+void putchar_roff(int c);
+void storeline(int c);
+int min(int value);
+int number(int default_val);
+int number1(int default_val);
+void text();
+void headin(char **header_ptr);
+void getname(char *name_buffer);
+void copyb();
+int nextfile();
+
+// Control command handlers implemented in roff2.cpp
+void case_ad();
+void case_br();
+void case_cc();
+void case_ce();
+void case_ds();
+void case_fi();
+void case_in();
+void case_ix();
+void case_li();
+void case_ll();
+void case_ls();
+void case_na();
+void case_ne();
+void case_nf();
+void case_pa();
+void case_bp();
+void case_bl();
+void case_pl();
+void case_sk();
+void case_sp();
+void case_ss();
+void case_tr();
+void case_ta();
+void case_ti();
+void case_ul();
+void case_un();
+void case_hx();
+void case_he();
+void case_fo();
+void case_eh();
+void case_oh();
+void case_ef();
+void case_of();
+void case_m1();
+void case_m2();
+void case_m3();
+void case_m4();
+void case_hc();
+void case_tc();
+void case_hy();
+void case_n1();
+void case_n2();
+void case_nn();
+void case_ni();
+void case_jo();
+void case_ar();
+void case_ro();
+void case_nx();
+void case_po();
+void case_de();
+void case_ig();
+void case_mk();


### PR DESCRIPTION
## Summary
- clean build scripts
- replace `roff_shared.h` with new `roff_globals.hpp`
- switch roff sources to use the new header

## Testing
- `pytest -q`
