### PR TITLE
Modernize 25 files to C++23

### DIFF
--- a/croff/hytab.hpp
+++ b/croff/hytab.hpp
@@ -2,6 +2,7 @@
  * hytab.cpp - Hyphenation Tables Implementation
  */
 
+#include "cxx23_scaffold.hpp" // Modern C++23 enforcement
 #include "hytab.hpp"
 #include <algorithm>
 #include <numeric>

--- a/croff/term/vt220_terminal.hpp
+++ b/croff/term/vt220_terminal.hpp
@@ -1,4 +1,4 @@
-
+#include "cxx23_scaffold.hpp" // Modern C++23 enforcement
 #include <array>
 #include <string_view>
 #include <span>

--- a/roff/hyphen_utils.cpp
+++ b/roff/hyphen_utils.cpp
@@ -1,5 +1,5 @@
 #include "cxx23_scaffold.hpp"
-#include <ctype.h>
+#include <cctype> // for std::isalpha and std::tolower
 #include "hyphen_utils.h"
 
 /* Simple helpers used by the old hyphenation code. */
@@ -7,13 +7,13 @@
 /*
  * Determine if character ``c`` is punctuation.
  */
-int punct(int c) {
+[[nodiscard]] constexpr int punct(int c) noexcept {
     if (c == 0)
         return 0;
-    return !isalpha((unsigned char)c);
+    return !std::isalpha(static_cast<unsigned char>(c));
 }
 
-int vowel(int c) {
-    c = tolower((unsigned char)c);
+[[nodiscard]] constexpr int vowel(int c) noexcept {
+    c = std::tolower(static_cast<unsigned char>(c));
     return c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' || c == 'y';
 }

--- a/roff/hyphen_utils.hpp
+++ b/roff/hyphen_utils.hpp
@@ -2,7 +2,7 @@
 #define HYPHEN_UTILS_H
 #include "cxx23_scaffold.hpp"
 
-int punct(int c);
-int vowel(int c);
+[[nodiscard]] constexpr int punct(int c) noexcept; // punctuation check
+[[nodiscard]] constexpr int vowel(int c) noexcept; // vowel check
 
 #endif /* HYPHEN_UTILS_H */

--- a/roff/roff.hpp
+++ b/roff/roff.hpp
@@ -38,6 +38,9 @@
 #include <span>
 #include <optional>
 #include <expected>
+
+// Roff version information for diagnostics
+inline constexpr std::string_view roff_version{"C++23-modern"};
 #include <memory>
 #include <ranges>
 #include <algorithm>

--- a/roff/roff1.cpp
+++ b/roff/roff1.cpp
@@ -214,7 +214,8 @@ class SafeBuffer {
 #define os_unlink unlink
 
 /* SCCS version identifier */
-static const char sccs_id[] ROFF_UNUSED = "@(#)roff1.c 1.3 25/05/29 (converted from PDP-11 assembly)";
+[[maybe_unused]] static constexpr std::string_view sccs_id =
+    "@(#)roff1.c 1.3 25/05/29 (converted from PDP-11 assembly)"; // ID string
 
 /* Buffer size constants */
 #define IBUF_SIZE 512 /**< Input buffer size */
@@ -324,7 +325,7 @@ static const control_entry_t control_table[] = {
     {"cc", case_cc}, /* Control character */
     {"ce", case_ce}, /* Center lines */
     /* Additional entries would go here... */
-    {"", NULL} /* Sentinel entry */
+    {"", nullptr} /* Sentinel entry */
 };
 
 /**
@@ -577,7 +578,7 @@ static void control_handler(void) {
     cmd[2] = '\0';
 
     /* Look up command in table */
-    for (i = 0; control_table[i].handler != NULL; i++) {
+    for (i = 0; control_table[i].handler != nullptr; i++) {
         if (strcmp(cmd, control_table[i].cmd) == 0) {
             control_table[i].handler();
             return;

--- a/roff/roff2.cpp
+++ b/roff/roff2.cpp
@@ -63,7 +63,8 @@
 #include "roff_globals.hpp" /* Shared globals and prototypes */
 
 /* SCCS version identifier */
-static const char sccs_id[] ROFF_UNUSED = "@(#)roff2.c 1.3 25/05/29 (converted from PDP-11 assembly)";
+[[maybe_unused]] static constexpr std::string_view sccs_id =
+    "@(#)roff2.c 1.3 25/05/29 (converted from PDP-11 assembly)"; // ID string
 
 /* External variables from roff1.c and other modules */
 

--- a/roff/roff3.cpp
+++ b/roff/roff3.cpp
@@ -72,7 +72,8 @@
 #include "roff.h" /* ROFF system definitions and globals */
 
 /* SCCS version identifier */
-static const char sccs_id[] ROFF_UNUSED = "@(#)roff3.c 1.3 25/05/29 (converted from PDP-11 assembly)";
+[[maybe_unused]] static constexpr std::string_view sccs_id =
+    "@(#)roff3.c 1.3 25/05/29 (converted from PDP-11 assembly)"; // ID string
 
 /* Constants for buffer sizes and limits */
 #define WORD_SIZE 64 /**< Maximum word length */
@@ -272,7 +273,7 @@ void rbreak(void) {
     }
 
     /* Terminate the current line with null byte */
-    if (linep != NULL) {
+    if (linep != nullptr) {
         *linep = '\0';
     }
 
@@ -302,12 +303,12 @@ void rbreak(void) {
             /* Output appropriate header based on page number parity */
             if ((pn & 1) == 0) {
                 /* Even page number */
-                if (ehead != NULL) {
+                if (ehead != nullptr) {
                     headout(&ehead);
                 }
             } else {
                 /* Odd page number */
-                if (ohead != NULL) {
+                if (ohead != nullptr) {
                     headout(&ohead);
                 }
             }
@@ -708,12 +709,12 @@ void eject(void) {
     /* Output appropriate footer based on page number parity */
     if ((pn & 1) == 0) {
         /* Even page number */
-        if (efoot != NULL) {
+        if (efoot != nullptr) {
             headout(&efoot);
         }
     } else {
         /* Odd page number */
-        if (ofoot != NULL) {
+        if (ofoot != nullptr) {
             headout(&ofoot);
         }
     }

--- a/roff/roff4.cpp
+++ b/roff/roff4.cpp
@@ -66,7 +66,8 @@
 #include "roff.h" /* ROFF system definitions and globals */
 
 /* SCCS version identifier */
-static const char sccs_id[] ROFF_UNUSED = "@(#)roff4.c 1.3 25/05/29 (converted from PDP-11 assembly)";
+[[maybe_unused]] static constexpr std::string_view sccs_id =
+    "@(#)roff4.c 1.3 25/05/29 (converted from PDP-11 assembly)"; // ID string
 
 /* Constants for text processing */
 #define DEFAULT_PAGE_LENGTH 66 /**< Default page length in lines */

--- a/roff/roff5.cpp
+++ b/roff/roff5.cpp
@@ -58,7 +58,8 @@
 static const char copyright[] ROFF_UNUSED = "Copyright 1972 Bell Telephone Laboratories Inc.";
 
 /* SCCS version identifier */
-static const char sccs_id[] ROFF_UNUSED = "@(#)roff5.c 1.3 25/05/29 (hyphenation engine - converted from PDP-11 assembly)";
+[[maybe_unused]] static constexpr std::string_view sccs_id =
+    "@(#)roff5.c 1.3 25/05/29 (hyphenation engine - converted from PDP-11 assembly)"; // ID string
 
 /* Constants for hyphenation algorithm */
 #define MAX_WORD_LENGTH 64 /**< Maximum word length for hyphenation */

--- a/roff/roff7.cpp
+++ b/roff/roff7.cpp
@@ -50,7 +50,8 @@
 static const char copyright[] ROFF_UNUSED = "Copyright 1972 Bell Telephone Laboratories Inc.";
 
 /* SCCS version identifier */
-static const char sccs_id[] ROFF_UNUSED = "@(#)roff7.c 1.3 25/05/29 (digram tables - converted from PDP-11 assembly)";
+[[maybe_unused]] static constexpr std::string_view sccs_id =
+    "@(#)roff7.c 1.3 25/05/29 (digram tables - converted from PDP-11 assembly)"; // ID string
 
 /**
  * @brief Beginning + consonant + vowel patterns table.

--- a/roff/roff8.cpp
+++ b/roff/roff8.cpp
@@ -43,7 +43,8 @@
 static const char copyright[] ROFF_UNUSED = "Copyright 1972 Bell Telephone Laboratories Inc.";
 
 /* SCCS version identifier */
-static const char sccs_id[] ROFF_UNUSED = "@(#)roff8.c 1.3 25/05/29 (global data - converted from PDP-11 assembly)";
+[[maybe_unused]] static constexpr std::string_view sccs_id =
+    "@(#)roff8.c 1.3 25/05/29 (global data - converted from PDP-11 assembly)"; // ID string
 
 /* Buffer size constants */
 #define LINE_SIZE 500 /**< Maximum line buffer size */
@@ -265,7 +266,7 @@ int nextb = 4;
  * @brief Include list pointer.
  * Points to current position in include file processing list.
  */
-int *ilistp = NULL; /* Will be set to ilist address during initialization */
+int *ilistp = nullptr; /* Will be set to ilist address during initialization */
 
 /*
  * =============================================================================
@@ -820,17 +821,17 @@ void init_globals(void) {
     nx = 0;
     ip = 0;
 
-    /* Initialize pointers to NULL */
-    argp = NULL;
-    ibufp = NULL;
-    eibuf = NULL;
-    maxloc = NULL;
-    hstart = NULL;
-    nhstart = NULL;
-    ehead = NULL;
-    ohead = NULL;
-    efoot = NULL;
-    ofoot = NULL;
+    /* Initialize pointers to null */
+    argp = nullptr;
+    ibufp = nullptr;
+    eibuf = nullptr;
+    maxloc = nullptr;
+    hstart = nullptr;
+    nhstart = nullptr;
+    ehead = nullptr;
+    ohead = nullptr;
+    efoot = nullptr;
+    ofoot = nullptr;
 }
 
 /**

--- a/roff/roff_globals.hpp
+++ b/roff/roff_globals.hpp
@@ -3,6 +3,7 @@
 #include "roff.h"
 #include "os_abstraction.h"
 #include <cstddef>
+#include "cxx23_scaffold.hpp" // Modern C++23 enforcement
 
 // Global variables defined in roff8.c
 extern int ad; // Adjust mode flag
@@ -60,12 +61,12 @@ void nlines(int count, int spacing);
 void topbot();
 void skipcont();
 void flushi();
-int getchar_roff();
+[[nodiscard]] int getchar_roff(); // return next input character
 void putchar_roff(int c);
 void storeline(int c);
-int min(int value);
-int number(int default_val);
-int number1(int default_val);
+[[nodiscard]] int min(int value); // clamp negative numbers
+[[nodiscard]] int number(int default_val); // parse number with default
+[[nodiscard]] int number1(int default_val); // parse number with spaces allowed
 void text();
 void headin(char **header_ptr);
 void getname(char *name_buffer);

--- a/roff/runtime.cpp
+++ b/roff/runtime.cpp
@@ -40,7 +40,7 @@ void mesg(int enable) {
  * column position.  The PDP-11 code kept this in ``ocol``; here it is
  * provided as an argument.
  */
-int dsp(int column) {
+[[nodiscard]] int dsp(int column) noexcept {
     int r = 0;
     do {
         r += 8;
@@ -55,7 +55,7 @@ int dsp(int column) {
  * Write the buffer contents to stdout and clear the index ``p`` so that
  * new data overwrites the previous output.
  */
-void flush_output(char *buf, size_t *p) {
+void flush_output(char *buf, size_t *p) noexcept {
     if (*p) {
         write(STDOUT_FILENO, buf, *p);
         *p = 0;

--- a/roff/runtime.hpp
+++ b/roff/runtime.hpp
@@ -11,9 +11,9 @@
 void mesg(int enable);
 
 /* Return distance to next 8-column tab stop from a column position. */
-int dsp(int column);
+[[nodiscard]] int dsp(int column) noexcept;
 
 /* Write buffer contents to stdout and reset the index pointer. */
-void flush_output(char *buf, size_t *p);
+void flush_output(char *buf, size_t *p) noexcept;
 
 #endif /* RUNTIME_H */

--- a/roff/sse_memops.cpp
+++ b/roff/sse_memops.cpp
@@ -1,6 +1,6 @@
 #include "cxx23_scaffold.hpp"
 #include "sse_memops.h"
-#include <string.h>
+#include <cstring> // std::memcpy/memcmp
 
 /*
  * Portable C versions of the fast memory routines that were
@@ -10,9 +10,9 @@
  * does not rely on assembly sources.
  */
 void *fast_memcpy(void *dst, const void *src, size_t n) {
-    return memcpy(dst, src, n);
+    return std::memcpy(dst, src, n); // delegate to standard
 }
 
 int fast_memcmp(const void *s1, const void *s2, size_t n) {
-    return memcmp(s1, s2, n);
+    return std::memcmp(s1, s2, n); // delegate to standard
 }

--- a/roff/sse_memops.hpp
+++ b/roff/sse_memops.hpp
@@ -3,10 +3,10 @@
 #define SSE_MEMOPS_H
 #include "cxx23_scaffold.hpp"
 
-#include <stddef.h>
+#include <cstddef>
 
 /* Prototypes for portable memory operations. */
-void *fast_memcpy(void *dst, const void *src, size_t n);
-int fast_memcmp(const void *s1, const void *s2, size_t n);
+[[nodiscard]] void *fast_memcpy(void *dst, const void *src, size_t n);
+[[nodiscard]] int fast_memcmp(const void *s1, const void *s2, size_t n);
 
 #endif /* SSE_MEMOPS_H */

--- a/roff/time_utils.cpp
+++ b/roff/time_utils.cpp
@@ -1,10 +1,10 @@
 #include "cxx23_scaffold.hpp"
 #include "time_utils.h"
-#include <time.h>
+#include <chrono> // C++23 time utilities
 
 /*
  * Return the current wall-clock time in seconds since the Epoch.
  */
-time_t current_time(void) {
-    return time(NULL);
+[[nodiscard]] time_t current_time(void) {
+    return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 }

--- a/roff/time_utils.hpp
+++ b/roff/time_utils.hpp
@@ -1,10 +1,11 @@
 #ifndef TIME_UTILS_H
 #define TIME_UTILS_H
 #include "cxx23_scaffold.hpp"
+#include <chrono>
 
 #include <time.h>
 
 /* Return the current time as a time_t value. */
-time_t current_time(void);
+[[nodiscard]] time_t current_time(void); // current wall-clock time
 
 #endif /* TIME_UTILS_H */

--- a/src/os/os_abstraction.hpp
+++ b/src/os/os_abstraction.hpp
@@ -18,15 +18,15 @@ extern "C" {
  * uniform C90 interface to the rest of the code base.
  */
 
-int os_open(const char *path, int flags, int mode);
-ssize_t os_read(int fd, void *buf, size_t count);
-ssize_t os_write(int fd, const void *buf, size_t count);
-int os_close(int fd);
-off_t os_lseek(int fd, off_t offset, int whence);
-int os_unlink(const char *path);
-int os_stat(const char *path, struct stat *buf);
-FILE *os_fopen(const char *path, const char *mode);
-int os_fclose(FILE *file);
+[[nodiscard]] int os_open(const char *path, int flags, int mode);
+[[nodiscard]] ssize_t os_read(int fd, void *buf, size_t count);
+[[nodiscard]] ssize_t os_write(int fd, const void *buf, size_t count);
+[[nodiscard]] int os_close(int fd);
+[[nodiscard]] off_t os_lseek(int fd, off_t offset, int whence);
+[[nodiscard]] int os_unlink(const char *path);
+[[nodiscard]] int os_stat(const char *path, struct stat *buf);
+[[nodiscard]] FILE *os_fopen(const char *path, const char *mode);
+[[nodiscard]] int os_fclose(FILE *file);
 
 #ifdef __cplusplus
 }

--- a/src/os/os_unix.cpp
+++ b/src/os/os_unix.cpp
@@ -7,38 +7,38 @@
  * POSIX system calls.
  */
 
-int os_open(const char *path, int flags, int mode) {
-    return open(path, flags, mode);
+[[nodiscard]] int os_open(const char *path, int flags, int mode) {
+    return open(path, flags, mode); // forward to POSIX open
 }
 
-ssize_t os_read(int fd, void *buf, size_t count) {
+[[nodiscard]] ssize_t os_read(int fd, void *buf, size_t count) {
     return read(fd, buf, count);
 }
 
-ssize_t os_write(int fd, const void *buf, size_t count) {
+[[nodiscard]] ssize_t os_write(int fd, const void *buf, size_t count) {
     return write(fd, buf, count);
 }
 
-int os_close(int fd) {
+[[nodiscard]] int os_close(int fd) {
     return close(fd);
 }
 
-off_t os_lseek(int fd, off_t offset, int whence) {
-    return lseek(fd, offset, whence);
+[[nodiscard]] off_t os_lseek(int fd, off_t offset, int whence) {
+    return lseek(fd, offset, whence); // reposition file offset
 }
 
-int os_unlink(const char *path) {
+[[nodiscard]] int os_unlink(const char *path) {
     return unlink(path);
 }
 
-int os_stat(const char *path, struct stat *buf) {
+[[nodiscard]] int os_stat(const char *path, struct stat *buf) {
     return stat(path, buf);
 }
 
-FILE *os_fopen(const char *path, const char *mode) {
+[[nodiscard]] FILE *os_fopen(const char *path, const char *mode) {
     return fopen(path, mode);
 }
 
-int os_fclose(FILE *file) {
+[[nodiscard]] int os_fclose(FILE *file) {
     return fclose(file);
 }

--- a/src/os/os_windows.cpp
+++ b/src/os/os_windows.cpp
@@ -36,12 +36,12 @@ int os_stat(const char *path, struct stat *buf) {
     return _stat(path, buf);
 }
 
-FILE *os_fopen(const char *path, const char *mode) {
-    FILE *f = NULL;
+[[nodiscard]] FILE *os_fopen(const char *path, const char *mode) {
+    FILE *f = nullptr; // std pointer initialization
     fopen_s(&f, path, mode);
     return f;
 }
 
-int os_fclose(FILE *file) {
+[[nodiscard]] int os_fclose(FILE *file) {
     return fclose(file);
 }

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -49,9 +49,9 @@ extern void skipcont(void);
 /* Output buffer base lives in roff8.c as a static array */
 /** Return pointer to start of output buffer (defined in roff8.c). */
 static char *obuf_base(void) {
-    static char *base_ptr = NULL;
+    static char *base_ptr = nullptr; // modern sentinel
 
-    if (base_ptr == NULL) {
+    if (base_ptr == nullptr) {
         base_ptr = obufp;
     }
 
@@ -190,7 +190,7 @@ void headin(char **p) {
     char buf[256];
     size_t len = 0;
 
-    if (p == NULL) {
+    if (p == nullptr) {
         return;
     }
 
@@ -208,7 +208,7 @@ void headin(char **p) {
 
     free(*p);
     *p = malloc(len + 1);
-    if (*p != NULL) {
+    if (*p != nullptr) {
         memcpy(*p, buf, len + 1);
     }
 
@@ -223,12 +223,12 @@ void headin(char **p) {
 void headout(char **p) {
     const char *s;
 
-    if (p == NULL || hx == 0) {
+    if (p == nullptr || hx == 0) {
         return;
     }
 
     s = *p;
-    if (s == NULL) {
+    if (s == nullptr) {
         return;
     }
 

--- a/suftab.cpp
+++ b/suftab.cpp
@@ -4,12 +4,13 @@
  * Modernized to C90 standards
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <array> // std::array for fixed data
+#include <cstdio>
+#include <cstdlib>
 #include "suftab.h"
 
 /* Suffix table data - modernized array declaration */
-const char suftab[4096] = {
+constexpr std::array<char, SUFTAB_SIZE> suftab = {
     // ...existing code...
 };
 

--- a/suftab.hpp
+++ b/suftab.hpp
@@ -6,12 +6,14 @@
 #ifndef SUFTAB_H
 #define SUFTAB_H
 #include "cxx23_scaffold.hpp"
+#include <array> // std::array container
+#include <span>
 
 /* External declarations */
-extern const char suftab[4096];
+extern const std::array<char, SUFTAB_SIZE> suftab; // suffix data storage
 
 /* Function prototypes */
-void print_suftab_info(void);
+void print_suftab_info(void); // display suffix table stats
 
 /* Utility macros */
 #define SUFTAB_SIZE 4096


### PR DESCRIPTION
## Summary
- enforce C++23 scaffold in various headers
- modernize OS abstraction and utility functions
- update time and hyphen utilities to modern C++
- convert suffix table to `std::array`
- replace `NULL` with `nullptr` and add constexpr constants

## Testing
- `pytest -q`