### PR TITLE
Upgrade small cpp helpers to C++23

### DIFF
--- a/roff/hyphen_utils.cpp
+++ b/roff/hyphen_utils.cpp
@@ -1,19 +1,23 @@
 #include "cxx23_scaffold.hpp"
-#include <cctype> // for std::isalpha and std::tolower
-#include "hyphen_utils.h"
+#include "hyphen_utils.hpp"
 
-/* Simple helpers used by the old hyphenation code. */
+#include <cctype>
+
+// Simple helpers used by the old hyphenation code.
+namespace roff::util {
 
 /*
  * Determine if character ``c`` is punctuation.
  */
-[[nodiscard]] constexpr int punct(int c) noexcept {
+[[nodiscard]] constexpr bool punct(int c) noexcept {
     if (c == 0)
-        return 0;
+        return false;
     return !std::isalpha(static_cast<unsigned char>(c));
 }
 
-[[nodiscard]] constexpr int vowel(int c) noexcept {
+[[nodiscard]] constexpr bool vowel(int c) noexcept {
     c = std::tolower(static_cast<unsigned char>(c));
     return c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' || c == 'y';
 }
+
+} // namespace roff::util

--- a/roff/hyphen_utils.hpp
+++ b/roff/hyphen_utils.hpp
@@ -1,8 +1,13 @@
 #ifndef HYPHEN_UTILS_H
 #define HYPHEN_UTILS_H
+
 #include "cxx23_scaffold.hpp"
 
-[[nodiscard]] constexpr int punct(int c) noexcept; // punctuation check
-[[nodiscard]] constexpr int vowel(int c) noexcept; // vowel check
+namespace roff::util {
 
-#endif /* HYPHEN_UTILS_H */
+[[nodiscard]] constexpr bool punct(int c) noexcept; // punctuation check
+[[nodiscard]] constexpr bool vowel(int c) noexcept; // vowel check
+
+} // namespace roff::util
+
+#endif // HYPHEN_UTILS_H

--- a/roff/sse_memops.cpp
+++ b/roff/sse_memops.cpp
@@ -1,6 +1,10 @@
 #include "cxx23_scaffold.hpp"
-#include "sse_memops.h"
-#include <cstring> // std::memcpy/memcmp
+#include "sse_memops.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <span>
 
 /*
  * Portable C versions of the fast memory routines that were
@@ -9,10 +13,22 @@
  * provided as normal functions so the rest of the codebase
  * does not rely on assembly sources.
  */
-void *fast_memcpy(void *dst, const void *src, size_t n) {
-    return std::memcpy(dst, src, n); // delegate to standard
+namespace roff::util {
+
+void *fast_memcpy(void *dst, const void *src, std::size_t n) {
+    std::span<std::byte> d{static_cast<std::byte *>(dst), n};
+    std::span<const std::byte> s{static_cast<const std::byte *>(src), n};
+    std::ranges::copy(s, d.begin());
+    return dst;
 }
 
-int fast_memcmp(const void *s1, const void *s2, size_t n) {
-    return std::memcmp(s1, s2, n); // delegate to standard
+int fast_memcmp(const void *s1, const void *s2, std::size_t n) {
+    std::span<const std::byte> a{static_cast<const std::byte *>(s1), n};
+    std::span<const std::byte> b{static_cast<const std::byte *>(s2), n};
+    auto mismatch = std::ranges::mismatch(a, b);
+    if (mismatch.in1 == a.end())
+        return 0;
+    return static_cast<int>(*mismatch.in1) - static_cast<int>(*mismatch.in2);
 }
+
+} // namespace roff::util

--- a/roff/sse_memops.hpp
+++ b/roff/sse_memops.hpp
@@ -5,8 +5,15 @@
 
 #include <cstddef>
 
-/* Prototypes for portable memory operations. */
-[[nodiscard]] void *fast_memcpy(void *dst, const void *src, size_t n);
-[[nodiscard]] int fast_memcmp(const void *s1, const void *s2, size_t n);
+#include <span>
 
-#endif /* SSE_MEMOPS_H */
+namespace roff::util {
+
+// Portable memory operations using modern C++ spans.
+[[nodiscard]] void *fast_memcpy(void *dst, const void *src, std::size_t n);
+
+[[nodiscard]] int fast_memcmp(const void *s1, const void *s2, std::size_t n);
+
+} // namespace roff::util
+
+#endif // SSE_MEMOPS_H

--- a/roff/time_utils.cpp
+++ b/roff/time_utils.cpp
@@ -1,10 +1,14 @@
 #include "cxx23_scaffold.hpp"
-#include "time_utils.h"
-#include <chrono> // C++23 time utilities
+#include "time_utils.hpp"
 
-/*
- * Return the current wall-clock time in seconds since the Epoch.
- */
-[[nodiscard]] time_t current_time(void) {
-    return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+#include <chrono>
+
+// Implementation of modern time helper routines.
+namespace roff::utils {
+
+[[nodiscard]] sys_seconds current_time() noexcept {
+    return std::chrono::time_point_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now());
 }
+
+} // namespace roff::utils

--- a/roff/time_utils.hpp
+++ b/roff/time_utils.hpp
@@ -1,11 +1,17 @@
 #ifndef TIME_UTILS_H
 #define TIME_UTILS_H
+
 #include "cxx23_scaffold.hpp"
+
 #include <chrono>
 
-#include <time.h>
+// Modern time alias for convenience
+namespace roff::utils {
+using sys_seconds =
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
 
-/* Return the current time as a time_t value. */
-[[nodiscard]] time_t current_time(void); // current wall-clock time
+// Return the current time as a std::chrono::sys_seconds value.
+[[nodiscard]] sys_seconds current_time() noexcept;
+} // namespace roff::utils
 
-#endif /* TIME_UTILS_H */
+#endif // TIME_UTILS_H

--- a/suftab.cpp
+++ b/suftab.cpp
@@ -1,21 +1,26 @@
 #include "cxx23_scaffold.hpp"
-/*
- * suftab.c - Suffix table for text processing
- * Modernized to C90 standards
- */
+#include "suftab.hpp"
 
-#include <array> // std::array for fixed data
-#include <cstdio>
-#include <cstdlib>
-#include "suftab.h"
+#include <array>
+#include <format>
+#include <print>
 
-/* Suffix table data - modernized array declaration */
+namespace roff::data {
+
+// Suffix table data - modernized array declaration
 constexpr std::array<char, SUFTAB_SIZE> suftab = {
     // ...existing code...
 };
 
-/* Function to print suffix table information */
-void print_suftab_info(void) {
-    printf("Suffix table size: %lu bytes\n", (unsigned long)sizeof(suftab));
-    printf("First few bytes: %d, %d, %d, %d\n", (unsigned char)suftab[0], (unsigned char)suftab[1], (unsigned char)suftab[2], (unsigned char)suftab[3]);
+// Function to print suffix table information
+void print_suftab_info() {
+    std::print("Suffix table size: {} bytes\n", suftab.size());
+    std::print(
+        "First few bytes: {}, {}, {}, {}\n",
+        static_cast<unsigned char>(suftab[0]),
+        static_cast<unsigned char>(suftab[1]),
+        static_cast<unsigned char>(suftab[2]),
+        static_cast<unsigned char>(suftab[3]));
 }
+
+} // namespace roff::data

--- a/suftab.hpp
+++ b/suftab.hpp
@@ -5,17 +5,20 @@
 
 #ifndef SUFTAB_H
 #define SUFTAB_H
+
 #include "cxx23_scaffold.hpp"
-#include <array> // std::array container
+
+#include <array>
 #include <span>
 
-/* External declarations */
+namespace roff::data {
+
+constexpr std::size_t SUFTAB_SIZE = 4096;
+
 extern const std::array<char, SUFTAB_SIZE> suftab; // suffix data storage
 
-/* Function prototypes */
-void print_suftab_info(void); // display suffix table stats
+void print_suftab_info(); // display suffix table stats
 
-/* Utility macros */
-#define SUFTAB_SIZE 4096
+} // namespace roff::data
 
-#endif /* SUFTAB_H */
+#endif // SUFTAB_H

--- a/tbl/t2.cpp
+++ b/tbl/t2.cpp
@@ -1,10 +1,11 @@
 #include "cxx23_scaffold.hpp"
-/* t2.c:  subroutine sequencing for one table */
 #include "tbl.h"
-#include <stdio.h>
-#include <stdlib.h>
-/* Execute all stages needed for a single table. */
-void tableput(void) {
+
+#include <cstdlib>
+#include <cstdio>
+
+// Execute all stages needed for a single table.
+void tableput() {
     saveline();
     savefill();
     ifdivert();


### PR DESCRIPTION
## Summary
- modernize utility files to use C++23 features
- introduce namespaced APIs for time, memory and hyphen helpers
- use spans and chrono types instead of raw pointers
- migrate suftab utilities to modern headers and `std::print`
- clean up tbl/t2.cpp includes and style

## Testing
- `pytest -q`