### PR TITLE
Modernize hyphen utilities

### DIFF
--- a/roff/hyphen_utils.cpp
+++ b/roff/hyphen_utils.cpp
@@ -2,6 +2,7 @@
 #include "hyphen_utils.hpp"
 
 #include <cctype>
+#include <ranges>
 
 // Simple helpers used by the old hyphenation code.
 namespace roff::util {
@@ -9,15 +10,20 @@ namespace roff::util {
 /*
  * Determine if character ``c`` is punctuation.
  */
+// Return true when ``c`` represents a punctuation character.
 [[nodiscard]] constexpr bool punct(int c) noexcept {
     if (c == 0)
-        return false;
+        return false; // Zero terminator is never punctuation
     return !std::isalpha(static_cast<unsigned char>(c));
 }
 
+// Return true when ``c`` is contained within ``vowel_table``.
 [[nodiscard]] constexpr bool vowel(int c) noexcept {
-    c = std::tolower(static_cast<unsigned char>(c));
-    return c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' || c == 'y';
+    if (c == 0)
+        return false; // Zero terminator is not a vowel
+    const char lower =
+        static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return std::ranges::contains(vowel_table, lower);
 }
 
 } // namespace roff::util

--- a/roff/hyphen_utils.hpp
+++ b/roff/hyphen_utils.hpp
@@ -3,10 +3,21 @@
 
 #include "cxx23_scaffold.hpp"
 
+#include <array>
+#include <cctype>
+#include <ranges>
+
 namespace roff::util {
 
-[[nodiscard]] constexpr bool punct(int c) noexcept; // punctuation check
-[[nodiscard]] constexpr bool vowel(int c) noexcept; // vowel check
+// Predefined table of vowel characters for quick lookup.
+inline constinit const std::array<char, 6> vowel_table{
+    'a', 'e', 'i', 'o', 'u', 'y'};
+
+// Determine whether ``c`` is punctuation.
+[[nodiscard]] constexpr bool punct(int c) noexcept;
+
+// Determine whether ``c`` is a vowel using ``vowel_table``.
+[[nodiscard]] constexpr bool vowel(int c) noexcept;
 
 } // namespace roff::util
 


### PR DESCRIPTION
## Summary
- modernize `hyphen_utils` with C++23 facilities
- keep punctuation/vowel helpers constexpr
- use a constinit array and `std::ranges::contains`

## Testing
- `pytest -q`
