### PR TITLE
Switch project to C++17

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,4 +2,4 @@ Checks: '-*,clang-analyzer-*'
 WarningsAsErrors: ''
 FormatStyle: file
 HeaderFilterRegex: '.*'
-ExtraArgs: ['--std=c++23']
+ExtraArgs: ['--std=c++17']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       CC: clang
       CXX: clang++
       CFLAGS: -std=c23
-      CXXFLAGS: -std=c++23
+      CXXFLAGS: -std=c++17
     steps:
     - uses: actions/checkout@v3
     - name: Install
@@ -17,6 +17,6 @@ jobs:
     - name: Test
       run: make test
     - name: clang-tidy
-      run: clang-tidy $(git ls-files '*.cpp' '*.c') -- -std=c++23
+      run: clang-tidy $(git ls-files '*.cpp' '*.c') -- -std=c++17
     - name: format-check
       run: clang-format -n $(git ls-files '*.c' '*.cpp' '*.h' '*.hpp')

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
         {
             "name": "default",
             "cStandard": "c23",
-            "cppStandard": "c++23",
+            "cppStandard": "c++17",
             "includePath": [],
             "defines": []
         }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 3.5)
 project(otroff C CXX)
 
 # Enforce ANSI C standard
-set(CMAKE_C_STANDARD 23)
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Detect the operating system

--- a/cxx17_scaffold.hpp
+++ b/cxx17_scaffold.hpp
@@ -1,18 +1,18 @@
 // ==========================================
-// === C++23 Scaffold Enforcement Header ===
+// === C++17 Scaffold Enforcement Header ===
 // === REMOVE OR INLINE ONCE STABILIZED! ===
 // ==========================================
 
-#ifndef CXX23_SCAFFOLD_HPP
-#define CXX23_SCAFFOLD_HPP
+#ifndef CXX17_SCAFFOLD_HPP
+#define CXX17_SCAFFOLD_HPP
 
 // Enforce strict compile-time C++ standard check
-#if __cplusplus < 202302L
-#error "C++23 or later is required. Set -std=c++23 or equivalent in your build system."
+#if __cplusplus < 201703L
+#error "C++17 or later is required. Set -std=c++17 or equivalent in your build system."
 #endif
 
 // Enable attributes, modules (if available), constexpr enhancements
-#define CXX23 [[nodiscard]] constexpr
+#define CXX17 [[nodiscard]] constexpr
 
 // Safe narrow cast: replace C-style casts
 #include <bit>
@@ -28,7 +28,7 @@ constexpr T narrow_cast(U value) {
     return static_cast<T>(value);
 }
 
-// Compile-time type reflection marker (C++23 feature)
+// Compile-time type reflection marker (C++17 feature)
 #if defined(__cpp_reflection) // not widely supported yet
 #warning "Native reflection supported. Consider integrating <experimental/reflection>."
 #endif
@@ -43,6 +43,6 @@ constexpr T narrow_cast(U value) {
 #endif
 
 // Placeholder macro for future linting, static analysis or CI
-#define MODERNIZED_BY_CXX23
+#define MODERNIZED_BY_CXX17
 
-#endif // CXX23_SCAFFOLD_HPP
+#endif // CXX17_SCAFFOLD_HPP

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('otroff', 'c', default_options : ['c_std=c23', 'cpp_std=c++23'])
+project('otroff', 'c', default_options : [ 'c_std=c17', 'cpp_std=c++17' ])
 
     roff_src = files(
         'roff/roff1.c',

--- a/roff/roff.hpp
+++ b/roff/roff.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
-// Enforce C++23 compilation
-#if __cplusplus < 202302L
-#error "This code requires C++23 or later. Use -std=c++23 or equivalent."
+// Enforce C++17 compilation
+#if __cplusplus < 201703L
+#error "This code requires C++17 or later. Use -std=c++17 or equivalent."
 #endif
 
 // Disable C compatibility
 #ifdef __STDC__
-#error "This is pure C++23 code. Do not compile with a C compiler."
+#error "This is pure C++17 code. Do not compile with a C compiler."
 #endif
 
-// Platform checks for C++23 features
+// Platform checks for C++17 features
 #ifndef __cpp_concepts
-#error "C++23 concepts support required"
+#error "C++17 concepts support required"
 #endif
 
 #ifndef __cpp_modules
@@ -20,10 +20,10 @@
 #endif
 
 #ifndef __cpp_consteval
-#error "C++23 consteval support required"
+#error "C++17 consteval support required"
 #endif
 
-// Modern C++23 includes - replace all C headers
+// Modern C++17 includes - replace all C headers
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -36,12 +36,12 @@
 #include <expected>
 #include <memory>
 
-// Force strict C++23 mode
+// Force strict C++17 mode
 #define PURE_CPP23_ONLY
 #include "cxx23_scaffold.hpp"
 
 // Roff version information for diagnostics
-inline constexpr std::string_view roff_version{"C++23-modern"};
+inline constexpr std::string_view roff_version{"C++17-modern"};
 #include <ranges>
 #include <algorithm>
 #include <format>
@@ -66,7 +66,7 @@ inline constexpr std::string_view roff_version{"C++23-modern"};
 
 namespace roff {
 
-// Core type aliases for modern C++23
+// Core type aliases for modern C++17
 using byte_t = std::byte;
 using size_type = std::size_t;
 using string = std::string;
@@ -88,7 +88,7 @@ using shared_ptr = std::shared_ptr<T>;
 template <typename T>
 using span = std::span<T>;
 
-// Compiler attribute macros (C++23 style)
+// Compiler attribute macros (C++17 style)
 #if defined(__clang__) || defined(__GNUC__)
 #define ROFF_UNUSED [[maybe_unused]]
 #define ROFF_NODISCARD [[nodiscard]]


### PR DESCRIPTION
## Summary
- declare C++17 as the required standard
- update build files and configuration
- update clang-tidy config to compile as C++17
- rename `cxx23_scaffold.hpp` to `cxx17_scaffold.hpp`
- bump headers to enforce C++17

## Testing
- `make test` *(fails: Makefile:4: *** empty variable name.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_6839f1bf33c48331b726a974fe750179