### PR TITLE
Refactor headers to C++17

### DIFF
--- a/roff/hyphen_utils.cpp
+++ b/roff/hyphen_utils.cpp
@@ -1,4 +1,4 @@
-#include "cxx23_scaffold.hpp"
+#include "cxx17_scaffold.hpp"
 #include "hyphen_utils.hpp"
 
 #include <cctype>

--- a/roff/hyphen_utils.hpp
+++ b/roff/hyphen_utils.hpp
@@ -1,7 +1,6 @@
-#ifndef HYPHEN_UTILS_H
-#define HYPHEN_UTILS_H
+#pragma once
 
-#include "cxx23_scaffold.hpp"
+#include "cxx17_scaffold.hpp"
 
 #include <array>
 #include <cctype>
@@ -20,5 +19,3 @@ inline constinit const std::array<char, 6> vowel_table{
 [[nodiscard]] constexpr bool vowel(int c) noexcept;
 
 } // namespace roff::util
-
-#endif // HYPHEN_UTILS_H

--- a/roff/runtime.cpp
+++ b/roff/runtime.cpp
@@ -1,11 +1,11 @@
-#include "cxx23_scaffold.hpp"
+#include "cxx17_scaffold.hpp"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h> /* defines mode_t */
 #include <sys/stat.h>
 #include <string.h>
-#include "runtime.h"
+#include "runtime.hpp"
 
 /*
  * Replacement implementations for small helper routines found in the
@@ -14,8 +14,9 @@
  */
 
 /*
- * Toggle write permission on the controlling terminal.  This mirrors the
- * behaviour of the historic mesg(1) command by adjusting group/world access.
+ * Toggle write permission on the controlling terminal.
+ * Mirrors the behaviour of the historic mesg(1) command by
+ * adjusting group/world access bits.
  */
 void mesg(int enable) {
     char *tty = ttyname(STDOUT_FILENO);
@@ -36,9 +37,9 @@ void mesg(int enable) {
 }
 
 /*
- * Calculate the distance to the next 8-column tab stop from the supplied
- * column position.  The PDP-11 code kept this in ``ocol``; here it is
- * provided as an argument.
+ * Calculate the distance to the next 8-column tab stop from ``column``.
+ * The original PDP-11 implementation stored this value in ``ocol``; here
+ * it is supplied directly as an argument.
  */
 [[nodiscard]] int dsp(int column) noexcept {
     int r = 0;
@@ -52,8 +53,8 @@ void mesg(int enable) {
 }
 
 /*
- * Write the buffer contents to stdout and clear the index ``p`` so that
- * new data overwrites the previous output.
+ * Write the buffer contents to stdout and reset ``p`` so that new data
+ * overwrites the previous output.
  */
 void flush_output(char *buf, size_t *p) noexcept {
     if (*p) {

--- a/roff/runtime.hpp
+++ b/roff/runtime.hpp
@@ -1,11 +1,11 @@
-/*
- * Runtime helper prototypes used across the roff utilities.
- */
-#ifndef RUNTIME_H
-#define RUNTIME_H
-#include "cxx23_scaffold.hpp"
+/// \file runtime.hpp
+/// \brief Helper routines used by roff utilities at runtime.
 
-#include <stddef.h>
+#pragma once
+
+#include "cxx17_scaffold.hpp"
+
+#include <cstddef>
 
 /* Enable or disable write permission on the controlling terminal. */
 void mesg(int enable);
@@ -15,5 +15,3 @@ void mesg(int enable);
 
 /* Write buffer contents to stdout and reset the index pointer. */
 void flush_output(char *buf, size_t *p) noexcept;
-
-#endif /* RUNTIME_H */

--- a/roff/time_utils.cpp
+++ b/roff/time_utils.cpp
@@ -1,4 +1,4 @@
-#include "cxx23_scaffold.hpp"
+#include "cxx17_scaffold.hpp"
 #include "time_utils.hpp"
 
 #include <chrono>
@@ -6,6 +6,7 @@
 // Implementation of modern time helper routines.
 namespace roff::utils {
 
+/// Obtain the current system time with second precision.
 [[nodiscard]] sys_seconds current_time() noexcept {
     return std::chrono::time_point_cast<std::chrono::seconds>(
         std::chrono::system_clock::now());

--- a/roff/time_utils.hpp
+++ b/roff/time_utils.hpp
@@ -1,17 +1,19 @@
-#ifndef TIME_UTILS_H
-#define TIME_UTILS_H
+/// \file time_utils.hpp
+/// \brief Utility functions for working with system time.
 
-#include "cxx23_scaffold.hpp"
+#pragma once
+
+#include "cxx17_scaffold.hpp"
 
 #include <chrono>
 
-// Modern time alias for convenience
 namespace roff::utils {
+
+/// Alias for system clock points with second precision.
 using sys_seconds =
     std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
 
-// Return the current time as a std::chrono::sys_seconds value.
+/// Return the current time as a ``sys_seconds`` value.
 [[nodiscard]] sys_seconds current_time() noexcept;
-} // namespace roff::utils
 
-#endif // TIME_UTILS_H
+} // namespace roff::utils

--- a/suftab.cpp
+++ b/suftab.cpp
@@ -1,4 +1,4 @@
-#include "cxx23_scaffold.hpp"
+#include "cxx17_scaffold.hpp"
 #include "suftab.hpp"
 
 #include <array>
@@ -12,7 +12,7 @@ constexpr std::array<char, SUFTAB_SIZE> suftab = {
     // ...existing code...
 };
 
-// Function to print suffix table information
+// Function to print suffix table information.
 void print_suftab_info() {
     std::print("Suffix table size: {} bytes\n", suftab.size());
     std::print(

--- a/suftab.hpp
+++ b/suftab.hpp
@@ -1,12 +1,11 @@
 /*
- * suftab.h - Suffix table interface
- * Header file for suffix table functionality
+ * suftab.hpp - Suffix table interface
+ * Modern header for suffix table functionality.
  */
 
-#ifndef SUFTAB_H
-#define SUFTAB_H
+#pragma once
 
-#include "cxx23_scaffold.hpp"
+#include "cxx17_scaffold.hpp"
 
 #include <array>
 #include <span>
@@ -20,5 +19,3 @@ extern const std::array<char, SUFTAB_SIZE> suftab; // suffix data storage
 void print_suftab_info(); // display suffix table stats
 
 } // namespace roff::data
-
-#endif // SUFTAB_H


### PR DESCRIPTION
## Summary
- migrate various headers to use `cxx17_scaffold.hpp`
- replace include guards with `#pragma once`
- modernize runtime/time utilities and suffix table headers
- update corresponding implementations
- keep all tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6839f6cd581c8331b63ee18681c3f8e8