### PR TITLE
Refactor troff buffers into TroffProcessor

### DIFF
--- a/croff/n10.cpp
+++ b/croff/n10.cpp
@@ -76,14 +76,15 @@
  */
 #define NROFF 1
 #include "tdef.hpp" /* Main definitions, likely includes t.hpp */
-#include "env.hpp"  /* Environment structure definition */
+#include "env.hpp" /* Environment structure definition */
 /* #include "t.hpp" -- Likely included by tdef.hpp */
-#include "tw.hpp"  /* Terminal/writer specific definitions */
+#include "tw.hpp" /* Terminal/writer specific definitions */
 #include <stdlib.h> /* For exit(), NULL */
 #include <unistd.h> /* For read(), close(), open(), lseek(), sbrk() if setbrk is a wrapper */
 #include <fcntl.h> /* For open() flags */
 #include <sys/wait.h> /* For wait() */
 #include "proto.hpp" /* Function prototypes for this project */
+#include "troff_processor.hpp" // processor state
 
 /* Explicit declaration to avoid implicit function warning */
 void flusho(void);
@@ -104,8 +105,7 @@ void oput(int c);
 
 /* External global variables, defined elsewhere */
 extern int lss; /* Current line spacing */
-extern char obuf[]; /* Output buffer */
-extern char *obufp; /* Pointer to current position in obuf */
+extern TroffProcessor g_processor; /* Shared processor state */
 extern int xfont; /* Current font selection */
 extern int esc; /* Horizontal escapement */
 extern int lead; /* Vertical leading */
@@ -270,7 +270,7 @@ void ptinit(void) {
  * Restores terminal settings and cleans up before exiting.
  */
 void twdone(void) {
-    obufp = obuf; /* Reset output buffer pointer */
+    g_processor.outputPtr = g_processor.outputBuffer.data(); /* Reset buffer pointer */
     oputs(t.twrest); /* Output terminal restoration string */
     flusho(); /* Flush any remaining output */
 

--- a/croff/troff_processor.cpp
+++ b/croff/troff_processor.cpp
@@ -1,0 +1,4 @@
+#include "troff_processor.hpp"
+
+// Global processor instance used across the troff modules.
+TroffProcessor g_processor{};

--- a/croff/troff_processor.hpp
+++ b/croff/troff_processor.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <array>
+#include <string>
+#include "tdef.hpp"
+
+// RAII class encapsulating global buffers and pointers used by troff.
+class TroffProcessor {
+  public:
+    // Input buffer and associated pointers
+    std::array<char, IBUFSZ> inputBuffer{}; // Primary input buffer
+    std::array<char, IBUFSZ> extraBuffer{}; // Secondary input buffer
+    char *inputPtr{inputBuffer.data()}; // Pointer into inputBuffer
+    char *extraPtr{extraBuffer.data()}; // Pointer into extraBuffer
+    char *endInput{inputBuffer.data()}; // End pointer for inputBuffer
+    char *endExtra{extraBuffer.data()}; // End pointer for extraBuffer
+
+    // Output buffer and pointer
+    std::array<char, OBUFSZ> outputBuffer{}; // Device output buffer
+    char *outputPtr{outputBuffer.data()}; // Pointer into outputBuffer
+
+    TroffProcessor() = default; // Constructor initializes pointers
+    ~TroffProcessor() = default; // Destructor performs no cleanup
+};
+
+extern TroffProcessor g_processor; // Global processor instance


### PR DESCRIPTION
## Summary
- add `TroffProcessor` class to own buffer state
- update n1.cpp to use the processor object
- update n2.cpp and n10.cpp to use the new output buffer

## Testing
- `clang-format -i croff/n1.cpp croff/n2.cpp croff/n10.cpp croff/troff_processor.hpp croff/troff_processor.cpp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a1b41e3b08331982b75adecc030e9